### PR TITLE
Fighters now rearm on the carrier when launching by @zwparchan

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -606,10 +606,13 @@ void AI::Step(const PlayerInfo &player)
 					( !(it->IsYours() ? thisIsLaunching : parent->Commands().Has(Command::DEPLOY)) ||
 					( isArmed && ! hasAmmo) || 
 					//no enemy nearby so recharge shields in carrier
-					( it->Attributes().Get("shields") && 
-					  it->Shields() < 0.9 && 
+					( it->Attributes().Get("shields") &&
+					  it->Shields() < 0.9 &&
 					  (!it->GetTargetShip() || !it->GetTargetShip()->GetGovernment()->IsEnemy(gov))) ||
-					( it->Attributes().Get("shields") && it->Shields() < 0.6)))
+					//low on fuel
+					  (!it->Fuel() && it->Attributes().Get("Fuel Capacity")) || 
+					//in combat with low shields
+					( it->Attributes().Get("shields") && it->Shields() < 0.6))) 
 			{
 				it->SetTargetShip(parent);
 				MoveTo(*it, command, parent->Position(), parent->Velocity(), 40., .8);

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -602,7 +602,9 @@ void AI::Step(const PlayerInfo &player)
 					it->SetParent(parent);
 				}
 			}
-			else if(parent && ((!it->IsYours() ? thisIsLaunching : parent->Commands().Has(Command::DEPLOY)) || (isArmed && ! hasAmmo)) )
+			else if(parent && 
+					(it->Attributes().Get("shields") && it->Shields() < 0.5f) 
+					&& ((!it->IsYours() ? thisIsLaunching : parent->Commands().Has(Command::DEPLOY)) || (isArmed && ! hasAmmo)))
 			{
 				it->SetTargetShip(parent);
 				MoveTo(*it, command, parent->Position(), parent->Velocity(), 40., .8);
@@ -1559,7 +1561,9 @@ void AI::Attack(Ship &ship, Command &command, const Ship &target)
 	// is not realistic, but it's a whole lot less annoying for the player when
 	// they are trying to hunt down and kill the last missile boat in a fleet.
 	if(isArmed && !hasAmmo)
-		shortestRange = 0.;
+			shortestRange = 0.;
+		
+
 	
 	// Deploy any fighters you are carrying.
 	if(!ship.IsYours())

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -1258,8 +1258,8 @@ bool AI::ShouldDock(const Ship &ship, const Ship &parent) const
 	double maxShields = ship.Attributes().Get("shields");
 	double maxHull = ship.Attributes().Get("hull");
 	double health = !maxShields ? .9 * ship.Hull() : ship.Hull() + .5 * ship.Shields();
-	bool useOwnHullRepair = ship.Attributes().Get("hull repair rate")
-			&& (maxHull - maxHull * ship.Hull()) / ship.Attributes().Get("hull repair rate") < MAX_HEAL_TIME;
+	bool useOwnHullRepair = ship.Hull() == 1 || (ship.Attributes().Get("hull repair rate")
+			&& (maxHull - maxHull * ship.Hull()) / ship.Attributes().Get("hull repair rate") < MAX_HEAL_TIME);
 	bool useParentHullRepair = !useOwnHullRepair && parent.Attributes().Get("hull repair rate");
 	bool useOwnShieldRepair = maxShields && ship.Attributes().Get("shield generation")
 			&& (maxShields - maxShields * ship.Shields()) / ship.Attributes().Get("shield generation") < MAX_HEAL_TIME;

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -1233,7 +1233,7 @@ bool AI::ShouldDock(const Ship &ship, const Ship &parent) const
 	static const int MAX_HEAL_TIME = 3600;
 	static const int COMBAT_RANGE = 600;
 	
-	if(!parent.BaysFree(ship.Attributes().Category() == "Fighter"))
+	if(!parent.BaysFree(ship.Attributes().Category() == "Fighter") || parent.IsDisabled())
 		return false;
 	
 	// Boarding your parent was already decided upon.
@@ -1269,8 +1269,8 @@ bool AI::ShouldDock(const Ship &ship, const Ship &parent) const
 			&& (maxShields - maxShields * ship.Shields()) / ship.Attributes().Get("shield generation") < MAX_HEAL_TIME;
 	bool useParentShieldRepair = maxShields && !useOwnShieldRepair && parent.Attributes().Get("shield generation");
 	
-	bool canFuel = ship.Fuel() < .01 && ship.Attributes().Get("fuel capacity") && (parent.Fuel() *
-			parent.Attributes().Get("fuel capacity") > parent.JumpFuel() + ship.Attributes().Get("fuel capacity"));
+	bool canFuel = ship.Fuel() < .005 && ship.Attributes().Get("fuel capacity") && (parent.Fuel() *
+			parent.Attributes().Get("fuel capacity") > parent.JumpFuel() + .75 * ship.Attributes().Get("fuel capacity"));
 	bool canUnload = ship.Cargo().Size() && !ship.Cargo().IsEmpty() && parent.Cargo().Size() && parent.Cargo().Free();
 	
 	// Assess the current threat level.

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -602,9 +602,14 @@ void AI::Step(const PlayerInfo &player)
 					it->SetParent(parent);
 				}
 			}
-			else if(parent && 
-					(it->Attributes().Get("shields") && it->Shields() < 0.5f) 
-					&& ((!it->IsYours() ? thisIsLaunching : parent->Commands().Has(Command::DEPLOY)) || (isArmed && ! hasAmmo)))
+			else if(parent &&
+					( !(it->IsYours() ? thisIsLaunching : parent->Commands().Has(Command::DEPLOY)) ||
+					( isArmed && ! hasAmmo) || 
+					//no enemy nearby so recharge shields in carrier
+					( it->Attributes().Get("shields") && 
+					  it->Shields() < 0.9 && 
+					  (!it->GetTargetShip() || !it->GetTargetShip()->GetGovernment()->IsEnemy(gov))) ||
+					( it->Attributes().Get("shields") && it->Shields() < 0.6)))
 			{
 				it->SetTargetShip(parent);
 				MoveTo(*it, command, parent->Position(), parent->Velocity(), 40., .8);
@@ -1561,9 +1566,7 @@ void AI::Attack(Ship &ship, Command &command, const Ship &target)
 	// is not realistic, but it's a whole lot less annoying for the player when
 	// they are trying to hunt down and kill the last missile boat in a fleet.
 	if(isArmed && !hasAmmo)
-			shortestRange = 0.;
-		
-
+		shortestRange = 0.;
 	
 	// Deploy any fighters you are carrying.
 	if(!ship.IsYours())

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -1263,8 +1263,9 @@ bool AI::ShouldDock(const Ship &ship, const Ship &parent) const
 	bool useParentHullRepair = !useOwnHullRepair && parent.Attributes().Get("hull repair rate");
 	bool useOwnShieldRepair = maxShields && ship.Attributes().Get("shield generation")
 			&& (maxShields - maxShields * ship.Shields()) / ship.Attributes().Get("shield generation") < MAX_HEAL_TIME;
-	bool canFuel = (ship.Fuel() < .01 && ship.Attributes().Get("fuel capacity")) && parent.Fuel() *
-			parent.Attributes().Get("fuel capacity") > parent.JumpFuel() + ship.Attributes().Get("fuel capacity");
+	bool useParentShieldRepair = maxShields && !useOwnShieldRepair && parent.Attributes().Get("shield generation");
+	bool canFuel = ship.Fuel() < .01 && ship.Attributes().Get("fuel capacity") && (parent.Fuel() *
+			parent.Attributes().Get("fuel capacity") > parent.JumpFuel() + ship.Attributes().Get("fuel capacity"));
 	bool canUnload = ship.Cargo().Size() && !ship.Cargo().IsEmpty() && parent.Cargo().Size() && parent.Cargo().Free();
 	
 	// Assess the current threat level.
@@ -1300,7 +1301,7 @@ bool AI::ShouldDock(const Ship &ship, const Ship &parent) const
 	// need refueling, are not fighting and either have full cargo or need your parent's
 	// repair functions, or are in combat but badly damaged.
 	bool dock = (isArmed && !hasAmmo) || canFuel || (!hasEnemy && canUnload)
-			|| (!hasEnemy && health < .9 && (useParentHullRepair || (maxShields && !useOwnShieldRepair)))
+			|| (!hasEnemy && health < .9 && (useParentHullRepair || useParentShieldRepair))
 			|| (health < .7 && hasEnemy && inCombat);
 	return dock;
 }

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -560,6 +560,19 @@ void AI::Step(const PlayerInfo &player)
 		bool isFighter = (category == "Fighter");
 		if(it->CanBeCarried())
 		{
+
+			bool isArmed=false, hasAmmo=false;
+			for(const Hardpoint &weapon : it->Weapons())
+			{
+				const Outfit *outfit = weapon.GetOutfit();
+				if(outfit && !weapon.IsAntiMissile())
+				{
+					isArmed = true;
+					if(!outfit->Ammo() || it->OutfitCount(outfit->Ammo()))
+						hasAmmo = true;
+				}
+			}
+
 			bool hasSpace = (parent && parent->BaysFree(isFighter) && !parent->GetGovernment()->IsEnemy(gov));
 			if(!hasSpace || parent->IsDestroyed() || parent->GetSystem() != it->GetSystem())
 			{
@@ -589,7 +602,7 @@ void AI::Step(const PlayerInfo &player)
 					it->SetParent(parent);
 				}
 			}
-			else if(parent && !(it->IsYours() ? thisIsLaunching : parent->Commands().Has(Command::DEPLOY)))
+			else if(parent && ((!it->IsYours() ? thisIsLaunching : parent->Commands().Has(Command::DEPLOY)) || (isArmed && ! hasAmmo)) )
 			{
 				it->SetTargetShip(parent);
 				MoveTo(*it, command, parent->Position(), parent->Velocity(), 40., .8);

--- a/source/AI.h
+++ b/source/AI.h
@@ -72,6 +72,7 @@ private:
 	void MoveEscort(Ship &ship, Command &command) const;
 	static void Refuel(Ship &ship, Command &command);
 	static bool CanRefuel(const Ship &ship, const StellarObject *target);
+	bool ShouldDock(const Ship &ship, const Ship &parent) const;
 	
 	static double TurnBackward(const Ship &ship);
 	static double TurnToward(const Ship &ship, const Point &vector);

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -1344,9 +1344,15 @@ void Ship::Launch(list<shared_ptr<Ship>> &ships)
 
 
 			//Refuel the fighter.
-			double toTransfer = std::max(ship->attributes.Get("fuel capacity") - ship->fuel, fuel);
+			double toTransfer = std::min(ship->attributes.Get("fuel capacity") - ship->fuel, fuel);
 			fuel -= toTransfer;
 			ship->fuel += toTransfer;
+
+			//if still low or out of fuel don't launch
+			if( ship->Fuel() < 0.25 && ship->attributes.Get("fuel capacity"))
+			{
+				continue;
+			}
 
 			ships.push_back(bay.ship);
 			double maxV = bay.ship->MaxVelocity();

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -1318,6 +1318,12 @@ void Ship::Launch(list<shared_ptr<Ship>> &ships)
 		{
 			std::shared_ptr<Ship> &ship = bay.ship;
 
+			//do not launch ships with low shields
+			if( ship->Shields() < .9)
+			{
+				continue;
+			}
+
 			//rearm fighters as they leave the bay
 			set<const Outfit *> toRefill;
 			for(const auto &it : ship->Weapons())

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -1319,7 +1319,7 @@ void Ship::Launch(list<shared_ptr<Ship>> &ships)
 			std::shared_ptr<Ship> &ship = bay.ship;
 
 			//do not launch ships with low shields
-			if( ship->Shields() < .9)
+			if( ship->Shields() < .9 && ship->Attributes().Get("shields"))
 			{
 				continue;
 			}

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -1322,7 +1322,7 @@ void Ship::Launch(list<shared_ptr<Ship>> &ships)
 			// resources are needed for self-preservation.
 			if(!inDanger && ship->Hull() < .9 && Attributes().Get("hull repair rate") && Hull() > .9)
 				continue;
-			if(!inDanger() && ship->Shields() < .9 && Attributes().Get("shield generation") && Shields() > .9)
+			if(!inDanger && ship->Shields() < .9 && Attributes().Get("shield generation") && Shields() > .9)
 				continue;
 			
 			// Re-arm fighters upon launching.
@@ -1349,12 +1349,12 @@ void Ship::Launch(list<shared_ptr<Ship>> &ships)
 			bool hasAmmo = false;
 			for(const Outfit *outfit : toRefill)
 			{
-				int neededAmmo = ship->Attributes().CanAdd(*outfit, Cargo().Get(outfit));
+				hasAmmo |= ship->OutfitCount(outfit);
+				int neededAmmo = ship->Attributes().CanAdd(*outfit, OutfitCount(outfit));
 				if(neededAmmo)
 				{
-					Cargo().Remove(outfit, neededAmmo);
+					AddOutfit(outfit, -neededAmmo);
 					ship->AddOutfit(outfit, neededAmmo);
-					hasAmmo = true;
 				}
 			}
 			
@@ -2285,6 +2285,8 @@ bool Ship::Carry(const shared_ptr<Ship> &ship)
 				ship->Cargo().TransferAll(&this->Cargo());
 			// Return any unused fuel to the carrier, in case a launching fighter may need it.
 			ship->TransferFuel(ship->fuel, this);
+			// Remove the existing BOARD command.
+			ship->commands.Clear(Command::BOARD);
 			return true;
 		}
 	return false;

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -1369,20 +1369,20 @@ void Ship::Launch(list<shared_ptr<Ship>> &ships)
 					|| (weaponCount == ammoWeapons + fuelWeapons && !(hasAmmo || ship->Fuel() > .75))))
 				continue;
 			
-			ships.push_back(bay.ship);
-			double maxV = bay.ship->MaxVelocity();
+			ships.push_back(ship);
+			double maxV = ship->MaxVelocity();
 			Angle launchAngle = angle + BAY_ANGLE[bay.facing];
 			Point v = velocity + (.3 * maxV) * launchAngle.Unit() + (.2 * maxV) * Angle::Random().Unit();
-			bay.ship->Place(position + angle.Rotate(bay.point), v, launchAngle);
-			bay.ship->SetSystem(currentSystem);
-			bay.ship->SetParent(shared_from_this());
+			ship->Place(position + angle.Rotate(bay.point), v, launchAngle);
+			ship->SetSystem(currentSystem);
+			ship->SetParent(shared_from_this());
 			// Fighters in your ship have the same temperature as your ship itself, so
 			// when they launch they should take their share of heat with them, so that
 			// the fighter and the mothership remain at the same temperature.
-			bay.ship->heat = heat * bay.ship->Mass() / Mass();
-			heat -= bay.ship->heat;
+			ship->heat = heat * ship->Mass() / Mass();
+			heat -= ship->heat;
 			
-			bay.ship.reset();
+			ship.reset();
 		}
 }
 

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -1316,6 +1316,26 @@ void Ship::Launch(list<shared_ptr<Ship>> &ships)
 	for(Bay &bay : bays)
 		if(bay.ship && !Random::Int(40 + 20 * bay.isFighter))
 		{
+			std::shared_ptr<Ship> &ship = bay.ship;
+
+			//rearm fighters as they leave the bay
+			set<const Outfit *> toRefill;
+			for(const auto &it : ship->Weapons())
+				if(it.GetOutfit() && it.GetOutfit()->Ammo())
+					toRefill.insert(it.GetOutfit()->Ammo());
+
+			// This is slower than just calculating the proper number to add, but
+			// that does not matter because this is not so time-consuming anyways.
+			for(const Outfit *outfit : toRefill)
+			{
+				while(ship->Attributes().CanAdd(*outfit))
+				{
+					if(Cargo().Get(outfit))
+						Cargo().Remove(outfit);
+					ship->AddOutfit(outfit, 1);
+				}
+			}
+
 			ships.push_back(bay.ship);
 			double maxV = bay.ship->MaxVelocity();
 			Angle launchAngle = angle + BAY_ANGLE[bay.facing];

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -2265,6 +2265,9 @@ bool Ship::Carry(const shared_ptr<Ship> &ship)
 			// When a fighter rejoins its mothership, its mass is added to the
 			// mothership but so is its accumulated heat.
 			heat += ship->heat;
+			// If this ship collected anything in space, try to unload it into the parent's cargo hold.
+			if(this->Cargo().Free() && !ship->Cargo().IsEmpty())
+				ship->Cargo().TransferAll(&this->Cargo());
 			return true;
 		}
 	return false;

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -1312,7 +1312,6 @@ void Ship::Launch(list<shared_ptr<Ship>> &ships)
 	if(!IsDestroyed() && (!commands.Has(Command::DEPLOY) || zoom != 1. || hyperspaceCount || cloak))
 		return;
 	
-	bool inDanger = !Shields() || IsDisabled() || Hull() < .6;
 	for(Bay &bay : bays)
 		if(bay.ship && !Random::Int(40 + 20 * bay.isFighter))
 		{
@@ -1320,6 +1319,7 @@ void Ship::Launch(list<shared_ptr<Ship>> &ships)
 
 			// Do not launch ships with low health if they can be repaired more, unless our
 			// resources are needed for self-preservation.
+			bool inDanger = !Shields() || IsDisabled() || Hull() < .6;
 			if(!inDanger && ship->Hull() < .9 && Attributes().Get("hull repair rate") && Hull() > .9)
 				continue;
 			if(!inDanger && ship->Shields() < .9 && Attributes().Get("shield generation") && Shields() > .9)
@@ -1360,8 +1360,8 @@ void Ship::Launch(list<shared_ptr<Ship>> &ships)
 			
 			// This ship will refuel naturally based on the carrier's fuel collection,
 			// but the carrier may have reserves to spare.
-			if(ship->Attributes().Get("fuel capacity"))
-				TransferFuel(ship->Attributes().Get("fuel capacity") - ship->fuel, &*ship);
+			if(ship->Attributes().Get("fuel capacity") && fuel > JumpFuel())
+				TransferFuel(min(ship->Attributes().Get("fuel capacity") - ship->fuel, fuel - JumpFuel()), &*ship);
 			
 			// Do not launch an unarmed fighter unless in danger.
 			if(!inDanger && ((weaponCount == fuelWeapons && ship->Fuel() < .75)

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -1342,6 +1342,12 @@ void Ship::Launch(list<shared_ptr<Ship>> &ships)
 				}
 			}
 
+
+			//Refuel the fighter.
+			double toTransfer = std::max(ship->attributes.Get("fuel capacity") - ship->fuel, fuel);
+			fuel -= toTransfer;
+			ship->fuel += toTransfer;
+
 			ships.push_back(bay.ship);
 			double maxV = bay.ship->MaxVelocity();
 			Angle launchAngle = angle + BAY_ANGLE[bay.facing];

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -2265,8 +2265,9 @@ bool Ship::Carry(const shared_ptr<Ship> &ship)
 			// When a fighter rejoins its mothership, its mass is added to the
 			// mothership but so is its accumulated heat.
 			heat += ship->heat;
-			// If this ship collected anything in space, try to unload it into the parent's cargo hold.
-			if(this->Cargo().Free() && !ship->Cargo().IsEmpty())
+			// If this ship collected anything in space, try to unload it into the parent's cargo hold,
+			// except for the player's fleet.
+			if(!this->GetGovernment()->IsPlayer() && this->Cargo().Free() && !ship->Cargo().IsEmpty())
 				ship->Cargo().TransferAll(&this->Cargo());
 			return true;
 		}

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -350,8 +350,9 @@ private:
 	void RemoveEscort(const Ship &ship);
 	// Get the hull amount at which this ship is disabled.
 	double MinimumHull() const;
-	// Add to this ship's hull or shields, and return the amount added. If the
+	// Add to this ship's fuel, hull, or shields, and return the amount added. If the
 	// ship is carrying fighters, add to them as well.
+	double AddFuel(double rate);
 	double AddHull(double rate);
 	double AddShields(double rate);
 	// Find out how much fuel is consumed by the hyperdrive of the given type.


### PR DESCRIPTION
Ref: endless-sky/endless-sky#1971

>This allows fighters to rearm missiles from the carriers cargo hold. This is one of the changes being considered for endless-sky/endless-sky#1939.
>The only real rough edge I've seen is that landing on a planet without an outfitter does not rearm your fighters, but I haven't tested much.