### PR TITLE
Allow modders to restrict physical access to a planet similarly to the way they can grant it. by @Hadron1776

### DIFF
--- a/source/Planet.cpp
+++ b/source/Planet.cpp
@@ -436,7 +436,7 @@ const vector<const System *> &Planet::WormholeSystems() const
 // land on this planet.
 bool Planet::IsAccessible(const Ship *ship) const
 {
-	// If the attribute is required yet not present, or prohibited yet present, landing is not allowed.
+	// If an attribute is required yet not present, or prohibited yet present, landing is not allowed.
 	static const string PREFIX[2] = {"requires: ", "prohibits: "};
 	static const string PREFIX_END[2] = {"requires:!", "prohibits:!"};
 	if(!ship)

--- a/source/Planet.cpp
+++ b/source/Planet.cpp
@@ -448,7 +448,7 @@ bool Planet::IsAccessible(const Ship *ship) const
 		auto end = attributes.lower_bound(PREFIX_END[i]);
 		for( ; it != end; ++it)
 		{
-			double val  = ship->Attributes().Get(it->substr(PREFIX[i].length()));
+			double val = ship->Attributes().Get(it->substr(PREFIX[i].length()));
 			if((!i && !val) || (i && val))
 				return false;
 		}

--- a/source/Planet.cpp
+++ b/source/Planet.cpp
@@ -438,27 +438,22 @@ bool Planet::IsAccessible(const Ship *ship) const
 {
 	// Check whether any of this planet's attributes are in the form of the
 	// string "requires: <attribute>"; if so the ship must have that attribute.
-	string PREFIX = "requires: ";
-	string PREFIX_END = "requires:!";
-	auto it = attributes.lower_bound(PREFIX);
-	auto end = attributes.lower_bound(PREFIX_END);
+	static const string PREFIX[2] = {"requires: ", "prohibits: "};
+	static const string PREFIX_END[2] = {"requires:!", "prohibits:!"};
 	if(!ship)
 		return false;
-	if(it != end)
+	for(int i = 0; i < 2; ++i)
+	{
+		auto it = attributes.lower_bound(PREFIX[i]);
+		auto end = attributes.lower_bound(PREFIX_END[i]);
 		for( ; it != end; ++it)
-			if(!ship->Attributes().Get(it->substr(PREFIX.length())))
+		{
+			double val  = ship->Attributes().Get(it->substr(PREFIX[i].length()));
+			if((!i && !val) || (i && val))
 				return false;
+		}
+	}
 	
-	// Check whether any of this planet's attributes are in the form of the
-	// string "prohibits: <attribute>"; if so the ship must not have that attribute.
-	PREFIX = "prohibits: ";
-	PREFIX_END = "prohibits:!";
-	it = attributes.lower_bound(PREFIX);
-	end = attributes.lower_bound(PREFIX_END);
-	if(it != end)
-		for( ; it != end; ++it)
-			if(ship->Attributes().Get(it->substr(PREFIX.length())))
-				return false;
 	
 	return true;
 }

--- a/source/Planet.cpp
+++ b/source/Planet.cpp
@@ -445,16 +445,14 @@ bool Planet::IsAccessible(const Ship *ship) const
 	if(!ship)
 		return false;
 	if(it != end)
-	{
 		for( ; it != end; ++it)
 			if(!ship->Attributes().Get(it->substr(PREFIX.length())))
 				return false;
-	}
 	
 	// Check whether any of this planet's attributes are in the form of the
-	// string "excludes: <attribute>"; if so the ship must not have that attribute.
-	PREFIX = "excludes: ";
-	PREFIX_END = "excludes:!";
+	// string "prohibits: <attribute>"; if so the ship must not have that attribute.
+	PREFIX = "prohibits: ";
+	PREFIX_END = "prohibits:!";
 	it = attributes.lower_bound(PREFIX);
 	end = attributes.lower_bound(PREFIX_END);
 	if(it != end)

--- a/source/Planet.cpp
+++ b/source/Planet.cpp
@@ -436,8 +436,6 @@ const vector<const System *> &Planet::WormholeSystems() const
 // land on this planet.
 bool Planet::IsAccessible(const Ship *ship) const
 {
-	// Check whether any of this planet's attributes are in the form of the
-	// string "requires: <attribute>"; if so the ship must have that attribute.
 	static const string PREFIX[2] = {"requires: ", "prohibits: "};
 	static const string PREFIX_END[2] = {"requires:!", "prohibits:!"};
 	if(!ship)
@@ -446,10 +444,10 @@ bool Planet::IsAccessible(const Ship *ship) const
 	{
 		auto it = attributes.lower_bound(PREFIX[i]);
 		auto end = attributes.lower_bound(PREFIX_END[i]);
+		 // If the attribute is required yet not present, or prohibited yet present, landing is not allowed.
 		for( ; it != end; ++it)
 		{
-			double val = ship->Attributes().Get(it->substr(PREFIX[i].length()));
-			if((!i && !val) || (i && val))
+			if(!(i ^ (ship->Attributes().Get(it->substr(PREFIX[i].length())) != 0.)))
 				return false;
 		}
 	}

--- a/source/Planet.cpp
+++ b/source/Planet.cpp
@@ -436,6 +436,7 @@ const vector<const System *> &Planet::WormholeSystems() const
 // land on this planet.
 bool Planet::IsAccessible(const Ship *ship) const
 {
+	// If the attribute is required yet not present, or prohibited yet present, landing is not allowed.
 	static const string PREFIX[2] = {"requires: ", "prohibits: "};
 	static const string PREFIX_END[2] = {"requires:!", "prohibits:!"};
 	if(!ship)
@@ -444,12 +445,10 @@ bool Planet::IsAccessible(const Ship *ship) const
 	{
 		auto it = attributes.lower_bound(PREFIX[i]);
 		auto end = attributes.lower_bound(PREFIX_END[i]);
-		 // If the attribute is required yet not present, or prohibited yet present, landing is not allowed.
 		for( ; it != end; ++it)
 			if(!i == !ship->Attributes().Get(it->substr(PREFIX[i].length())))
 				return false;
 	}
-	
 	
 	return true;
 }

--- a/source/Planet.cpp
+++ b/source/Planet.cpp
@@ -442,13 +442,26 @@ bool Planet::IsAccessible(const Ship *ship) const
 	static const string PREFIX_END = "requires:!";
 	auto it = attributes.lower_bound(PREFIX);
 	auto end = attributes.lower_bound(PREFIX_END);
-	if(it == end)
-		return true;
 	if(!ship)
 		return false;
+	if(it != end)
+	{
+		for( ; it != end; ++it)
+			if(!ship->Attributes().Get(it->substr(PREFIX.length())))
+				return false;
+	}
+	
+	// Check whether any of this planet's attributes are in the form of the
+	// string "excludes: <attribute>"; if so the ship must not have that attribute.
+	static const string PREFIX_B = "excludes: ";
+	static const string PREFIX_B_END = "excludes:!";
+	it = attributes.lower_bound(PREFIX_B);
+	end = attributes.lower_bound(PREFIX_B_END);
+	if(it == end)
+		return true;
 	
 	for( ; it != end; ++it)
-		if(!ship->Attributes().Get(it->substr(PREFIX.length())))
+		if(ship->Attributes().Get(it->substr(PREFIX_B.length())))
 			return false;
 	
 	return true;

--- a/source/Planet.cpp
+++ b/source/Planet.cpp
@@ -446,10 +446,8 @@ bool Planet::IsAccessible(const Ship *ship) const
 		auto end = attributes.lower_bound(PREFIX_END[i]);
 		 // If the attribute is required yet not present, or prohibited yet present, landing is not allowed.
 		for( ; it != end; ++it)
-		{
-			if(!(i ^ (ship->Attributes().Get(it->substr(PREFIX[i].length())) != 0.)))
+			if(!i != !ship->Attributes().Get(it->substr(PREFIX[i].length())))
 				return false;
-		}
 	}
 	
 	

--- a/source/Planet.cpp
+++ b/source/Planet.cpp
@@ -446,7 +446,7 @@ bool Planet::IsAccessible(const Ship *ship) const
 		auto end = attributes.lower_bound(PREFIX_END[i]);
 		 // If the attribute is required yet not present, or prohibited yet present, landing is not allowed.
 		for( ; it != end; ++it)
-			if(!i != !ship->Attributes().Get(it->substr(PREFIX[i].length())))
+			if(!i == !ship->Attributes().Get(it->substr(PREFIX[i].length())))
 				return false;
 	}
 	

--- a/source/Planet.cpp
+++ b/source/Planet.cpp
@@ -438,8 +438,8 @@ bool Planet::IsAccessible(const Ship *ship) const
 {
 	// Check whether any of this planet's attributes are in the form of the
 	// string "requires: <attribute>"; if so the ship must have that attribute.
-	static const string PREFIX = "requires: ";
-	static const string PREFIX_END = "requires:!";
+	string PREFIX = "requires: ";
+	string PREFIX_END = "requires:!";
 	auto it = attributes.lower_bound(PREFIX);
 	auto end = attributes.lower_bound(PREFIX_END);
 	if(!ship)
@@ -453,16 +453,14 @@ bool Planet::IsAccessible(const Ship *ship) const
 	
 	// Check whether any of this planet's attributes are in the form of the
 	// string "excludes: <attribute>"; if so the ship must not have that attribute.
-	static const string PREFIX_B = "excludes: ";
-	static const string PREFIX_B_END = "excludes:!";
-	it = attributes.lower_bound(PREFIX_B);
-	end = attributes.lower_bound(PREFIX_B_END);
-	if(it == end)
-		return true;
-	
-	for( ; it != end; ++it)
-		if(ship->Attributes().Get(it->substr(PREFIX_B.length())))
-			return false;
+	PREFIX = "excludes: ";
+	PREFIX_END = "excludes:!";
+	it = attributes.lower_bound(PREFIX);
+	end = attributes.lower_bound(PREFIX_END);
+	if(it != end)
+		for( ; it != end; ++it)
+			if(ship->Attributes().Get(it->substr(PREFIX.length())))
+				return false;
 	
 	return true;
 }


### PR DESCRIPTION
Ref: endless-sky/endless-sky#3646

> In the `master` branch, one can limit a planet's accessibility with `requires: <attribute>`, which makes the planet inaccessible to any ship that does not have that attribute.
> 
> This PR adds a similar check for attributes of the form `prohibits: <attribute>`, which denies access to any ship that _does_ have that attribute.

