### PR TITLE
Adds extra response to the "Alondo is gay" revelation by @elgeonmb

### DIFF
--- a/data/free worlds middle.txt
+++ b/data/free worlds middle.txt
@@ -1596,7 +1596,7 @@ mission "FW Albatross 1"
 			`	"Yes," she says. "Yes, it does. Now, let's go meet up with JJ."`
 				accept
 			label metoo
-			`	Freya raises an eyebrow. "I hadn't heard. Let's hope nobody on Albatross had heard either."`
+			`	Freya raises an eyebrow. "I hadn't heard. Try not to say that so loudly when you're on Albatross."`
 				accept
 
 

--- a/data/free worlds middle.txt
+++ b/data/free worlds middle.txt
@@ -1589,11 +1589,15 @@ mission "FW Albatross 1"
 			choice
 				`	"Okay, I feel silly for even asking. Let's go meet up with JJ!"`
 					accept
+				`	"So am I."`
+					goto metoo
 				`	"Ah. That certainly explains a lot."`
 				`	"It seems crazy that anyone would be bothered by that in this day and age."`
 			`	"Yes," she says. "Yes, it does. Now, let's go meet up with JJ."`
 				accept
-
+			label metoo
+			`	Freya raises an eyebrow. "I hadn't heard. Let's hope nobody on Albatross had heard either."`
+				accept
 
 
 mission "FW Albatross 2"


### PR DESCRIPTION
Ref: endless-sky/endless-sky#3705

>As a huge lesbian I thought it kind of strange that, in revealing that Alondo is gay, the game implies that the PC isn't (by sending you on the diplomacy mission that Alondo is too gay to go on). Since ES aggressively avoids implying anything about the PC other than their place of birth and vague age/backstory elements, I figured I'd add a response to Freyja that allows you to dispel that implication.