### PR TITLE
Display cloaking energy and heat by @Nescio0

### DIFF
--- a/data/tooltips.txt
+++ b/data/tooltips.txt
@@ -293,6 +293,9 @@ tip "repairing hull:"
 tip "charging shields:"
 	`Energy consumed and heat generated when this ship is recharging its shields. This is in addition to the "idle" amount.`
 
+tip "cloaking:"
+	`Energy consumed and heat generated when this ship is cloaked. This is in addition to the "idle" amount.`
+
 tip "max:"
 	`Energy storage capacity and maximum safe level for heat generation. Energy capacity allows a ship to temporarily draw more energy than it produces. The heat maximum is the highest your heat generation can be without eventually causing your ship to overheat.`
 

--- a/source/ShipInfoDisplay.cpp
+++ b/source/ShipInfoDisplay.cpp
@@ -301,6 +301,12 @@ void ShipInfoDisplay::UpdateAttributes(const Ship &ship, const Depreciation &dep
 	double hullHeat = attributes.Get("hull heat");
 	heatTable.push_back(Format::Number(60. * (shieldHeat + hullHeat)));
 	attributesHeight += 20;
+	tableLabels.push_back("cloaking:");
+	double cloakingEnergy = attributes.Get("cloaking energy");
+	energyTable.push_back(Format::Number(-60. * cloakingEnergy));
+	double cloakingHeat = attributes.Get("cloaking heat");
+	heatTable.push_back(Format::Number(60. * cloakingHeat));
+	attributesHeight += 20;
 	tableLabels.push_back("max:");
 	energyTable.push_back(Format::Number(attributes.Get("energy capacity")));
 	heatTable.push_back(Format::Number(60. * ship.HeatDissipation() * ship.MaximumHeat()));

--- a/source/ShipInfoDisplay.cpp
+++ b/source/ShipInfoDisplay.cpp
@@ -301,12 +301,13 @@ void ShipInfoDisplay::UpdateAttributes(const Ship &ship, const Depreciation &dep
 	double hullHeat = attributes.Get("hull heat");
 	heatTable.push_back(Format::Number(60. * (shieldHeat + hullHeat)));
 	attributesHeight += 20;
-	tableLabels.push_back("cloaking:");
-	double cloakingEnergy = attributes.Get("cloaking energy");
-	energyTable.push_back(Format::Number(-60. * cloakingEnergy));
-	double cloakingHeat = attributes.Get("cloaking heat");
-	heatTable.push_back(Format::Number(60. * cloakingHeat));
-	attributesHeight += 20;
+	if(attributes.Get("cloak"))
+	{	
+		tableLabels.push_back("cloaking:");
+		energyTable.push_back(Format::Number(-60. * attributes.Get("cloaking energy")));
+		heatTable.push_back(Format::Number(60. * attributes.Get("cloaking heat")));
+		attributesHeight += 20;
+	}
 	tableLabels.push_back("max:");
 	energyTable.push_back(Format::Number(attributes.Get("energy capacity")));
 	heatTable.push_back(Format::Number(60. * ship.HeatDissipation() * ship.MaximumHeat()));


### PR DESCRIPTION
Ref: endless-sky/endless-sky#3835

> Display cloaking energy and heat in ship information table:
> ![42452031-4011fcce-8389-11e8-97f6-efa597b39654](https://user-images.githubusercontent.com/22377202/46694340-c9ac8280-cc0c-11e8-9033-24119a063cd8.png)
