### PR TITLE
Tweak default ship and variant loadouts to reflect missile changes by @Pointedstick

### DIFF
--- a/data/fleets.txt
+++ b/data/fleets.txt
@@ -299,7 +299,7 @@ fleet "Large Core Merchants"
 	variant 10
 		"Bulk Freighter" 2
 		"Protector" 1
-    variant 10
+	variant 10
 		"Bulk Freighter" 2
 		"Wasp" 3
 		"Wasp (Bomber)" 2

--- a/data/fleets.txt
+++ b/data/fleets.txt
@@ -234,7 +234,7 @@ fleet "Large Core Merchants"
 	variant 50
 		"Bulk Freighter"
 		"Wasp (Proton)" 2
-    variant 50
+	variant 50
 		"Bulk Freighter"
 		"Wasp"
 		"Wasp (Bomber)"
@@ -247,7 +247,7 @@ fleet "Large Core Merchants"
 	variant 10
 		"Bulk Freighter (Proton)"
 		"Wasp (Proton)" 2
-    variant 10
+	variant 10
 		"Bulk Freighter (Proton)"
 		"Wasp"
 		"Wasp (Bomber)"
@@ -315,7 +315,7 @@ fleet "Large Core Merchants"
 	variant 1
 		"Bulk Freighter (Heavy)" 2
 		"Vanguard (Particle)" 1
-    variant 1
+	variant 1
 		"Bulk Freighter (Heavy)" 2
 		"Vanguard (Missile)" 1
 	variant 20
@@ -356,11 +356,11 @@ fleet "Paradise Merchants"
 	variant 3
 		"Star Queen"
 		"Wasp (Proton)" 3
-    variant 2
+	variant 2
 		"Star Queen"
 		"Wasp" 2
 		"Wasp (Bomber)"
-    variant 2
+	variant 2
 		"Star Queen"
 		"Berserker" 3
 	variant 2
@@ -904,7 +904,7 @@ fleet "Small Free Worlds"
 		"Hawk (Plasma)"
 	variant 1
 		"Hawk (Speedy)"
-    variant 1
+	variant 1
 		"Hawk (Bomber)"
 	variant 2
 		"Sparrow"
@@ -919,7 +919,7 @@ fleet "Small Free Worlds"
 	variant 2
 		"Hawk (Speedy)"
 		"Sparrow" 2
-    variant 2
+	variant 2
 		"Hawk (Bomber)"
 		"Sparrow" 2
 	variant 2
@@ -1005,10 +1005,10 @@ fleet "Large Free Worlds"
 		"Falcon (Heavy)"
 		"Bastion (Heavy)"
 		"Hawk (Rocket)"
-    variant 2
+	variant 2
 		"Hawk (Rocket)" 2
 		"Sparrow" 4
-    variant 2
+	variant 2
 		"Falcon (Heavy)"
 		"Bastion (Heavy)"
 		"Hawk (Bomber)"
@@ -1016,7 +1016,7 @@ fleet "Large Free Worlds"
 		"Falcon (Laser)"
 		"Bastion (Laser)"
 		"Hawk (Speedy)"
-    variant 2
+	variant 2
 		"Falcon (Laser)"
 		"Bastion (Laser)"
 		"Hawk (Bomber)"
@@ -1551,7 +1551,7 @@ fleet "Large Syndicate"
 		"Protector"
 	variant 1
 		"Vanguard"
-    variant 1
+	variant 1
 		"Vanguard (Missile)"
 	variant 1
 		"Protector (Laser)"
@@ -1572,7 +1572,7 @@ fleet "Large Syndicate"
 	variant 1
 		"Vanguard"
 		"Quicksilver (Proton)" 2
-    variant 1
+	variant 1
 		"Vanguard (Missile)"
 		"Quicksilver (Proton)" 2
 
@@ -1601,7 +1601,7 @@ fleet "Small Southern Pirates"
 		"Fury (Gatling)"
 	variant 1
 		"Fury (Missile)"
-    variant 1
+	variant 1
 		"Fury (Heavy)"
 	variant 4
 		"Sparrow" 2
@@ -1615,7 +1615,7 @@ fleet "Small Southern Pirates"
 		"Fury" 3
 	variant 1
 		"Fury (Missile)" 3
-    variant 1
+	variant 1
 		"Fury (Heavy)" 2
 	variant 1
 		"Fury"
@@ -1686,7 +1686,7 @@ fleet "Large Southern Pirates"
 	variant 1
 		"Clipper (Heavy)"
 		"Hawk (Rocket)"
-    variant 2
+	variant 2
 		"Hawk (Bomber)"
 		"Sparrow" 3
 	variant 2
@@ -1695,7 +1695,7 @@ fleet "Large Southern Pirates"
 	variant 1
 		"Clipper (Speedy)"
 		"Hawk (Speedy)"
-    variant 1
+	variant 1
 		"Hawk (Bomber)"
 		"Fury (Gatling)" 2
 	variant 1
@@ -1727,7 +1727,7 @@ fleet "Large Southern Pirates"
 		"Sparrow" 2
 	variant 1
 		"Modified Argosy (Missile)" 2
-    variant 1
+	variant 1
 		"Fury (Heavy)" 2
 		"Modified Argosy (Missile)"
 	variant 4
@@ -1738,7 +1738,7 @@ fleet "Large Southern Pirates"
 		"Bastion (Laser)"
 	variant 2
 		"Falcon"
-    variant 1
+	variant 1
 		"Falcon"
 		"Sparrow" 3
 	variant 1
@@ -1895,13 +1895,13 @@ fleet "Small Core Pirates"
 		"Headhunter (Particle)"
 	variant 2
 		"Quicksilver" 2
-    variant 1
+	variant 1
 		"Hawk (Bomber)"
 		"Sparrow"
 	variant 1
 		"Fury (Bomber)"
 		"Sparrow"
-    variant 1
+	variant 1
 		"Fury (Heavy)"
 
 fleet "Large Core Pirates"
@@ -1920,19 +1920,19 @@ fleet "Large Core Pirates"
 	variant 3
 		"Splinter (Laser)"
 		"Quicksilver"
-    variant 2
+	variant 2
 		"Hawk (Bomber)"
 		"Quicksilver" 2
-    variant 1
+	variant 1
 		"Fury (Heavy)"
 		"Splinter"
-    variant 2
+	variant 2
 		"Hawk (Bomber)"
 		"Quicksilver (Proton)" 2
 	variant 3
 		"Fury (Bomber)"
 		"Quicksilver" 2
-    variant 3
+	variant 3
 		"Fury (Bomber)"
 		"Quicksilver (Proton)" 2
 	variant 2
@@ -1983,7 +1983,7 @@ fleet "Small Northern Pirates"
 		"Fury (Laser)"
 	variant 1
 		"Fury (Bomber)"
-    variant 1
+	variant 1
 		"Fury (Heavy)"
 	variant 2
 		"Berserker"
@@ -1997,7 +1997,7 @@ fleet "Small Northern Pirates"
 		"Hawk (Rocket)"
 	variant 1
 		"Hawk (Speedy)"
-    variant 1
+	variant 1
 		"Hawk (Bomber)"
 		"Sparrow"
 	variant 3
@@ -2097,7 +2097,7 @@ fleet "Large Northern Pirates"
 		"Leviathan (Heavy)"
 	variant 1
 		"Berserker" 3
-    variant 1
+	variant 1
 		"Fury (Heavy)" 2
 		"Firebird (Missile)"
 	variant 1
@@ -2143,7 +2143,7 @@ fleet "pirate raid"
 		"Hawk (Speedy)"
 	variant 6
 		"Hawk (Speedy)" 3
-    variant 4
+	variant 4
 		"Hawk (Bomber)" 2
 	variant 4
 		"Fury (Bomber)" 2
@@ -2227,7 +2227,7 @@ fleet "pirate raid"
 		"Raven (Heavy)" 2
 	variant 1
 		"Headhunter (Particle)" 3
-    variant 1
+	variant 1
 		"Fury (Heavy)" 2
 		"Firebird (Missile)"
 	variant 2
@@ -2266,7 +2266,7 @@ fleet "Syndicate Extremists"
 	variant 1
 		"Vanguard"
 		"Quicksilver" 2
-    variant 1
+	variant 1
 		"Vanguard (Missile)"
 		"Quicksilver (Proton)" 2
 	variant 1
@@ -2290,7 +2290,7 @@ fleet "Bounty Hunters"
 	variant 5
 		"Hawk" 2
 		"Hawk (Rocket)" 2
-    variant 5
+	variant 5
 		"Hawk"
 		"Hawk (Bomber)"
 		"Sparrow" 2
@@ -2327,7 +2327,7 @@ fleet "Bounty Hunters"
 	variant 1
 		"Splinter"
 		"Fury (Missile)"
-    variant 1
+	variant 1
 		"Splinter"
 		"Fury (Heavy)"
 
@@ -2869,7 +2869,7 @@ fleet "Hired Guns"
 	variant 1
 		"Vanguard (Particle)"
 		"Modified Argosy" 2
-    variant 1
+	variant 1
 		"Vanguard (Missile)"
 		"Headhunter (Strike)" 2
 	variant 1

--- a/data/fleets.txt
+++ b/data/fleets.txt
@@ -423,7 +423,7 @@ fleet "Small Northern Merchants"
 		"Berserker (Afterburner)"
 	variant 3
 		"Freighter"
-		"Berserker (Strike Fighter)"
+		"Berserker (Strike)"
 	variant 5
 		"Freighter (Fancy)"
 		"Shuttle" 4
@@ -471,7 +471,7 @@ fleet "Large Northern Merchants"
 		"Berserker (Afterburner)" 2
 	variant 3
 		"Freighter" 2
-		"Berserker (Strike Fighter)" 2
+		"Berserker (Strike)" 2
 	variant 10
 		"Freighter" 2
 		"Firebird (Plasma)"
@@ -528,7 +528,7 @@ fleet "Large Northern Merchants"
 		"Behemoth (Proton)"
 	variant 10
 		"Behemoth"
-		"Berserker (Strike Fighter)" 3
+		"Berserker (Strike)" 3
 	variant 10
 		"Behemoth" 2
 	variant 1
@@ -595,7 +595,7 @@ fleet "Large Northern Merchants"
 		"Headhunter (Particle)" 3
 	variant 1
 		"Star Queen"
-		"Berserker (Strike Fighter)" 2
+		"Berserker (Strike)" 2
 	variant 1
 		"Star Queen"
 		"Leviathan (Heavy)"
@@ -1252,7 +1252,7 @@ fleet "Small Deep Merchants"
 	variant 3
 		"Headhunter"
 	variant 1
-		"Headhunter (Heavy Strike Fighter)"
+		"Headhunter (Strike)"
 	variant 3
 		"Flivver"
 	variant 2
@@ -1315,7 +1315,7 @@ fleet "Large Deep Merchants"
 	variant 1
 		"Star Queen"
 		"Headhunter (Particle)"
-		"Headhunter (Heavy Strike Fighter)"
+		"Headhunter (Strike)"
 	variant 1
 		"Star Queen"
 		"Raven (Afterburner)" 2
@@ -1341,7 +1341,7 @@ fleet "Small Deep Security"
 	variant 2
 		"Headhunter (Particle)"
 	variant 2
-		"Headhunter (Heavy Strike Fighter)"
+		"Headhunter (Strike)"
 	variant 4
 		"Corvette"
 	variant 2
@@ -1390,7 +1390,7 @@ fleet "Large Deep Security"
 		"Headhunter (Particle)" 2
 	variant 2
 		"Headhunter (Particle)"
-		"Headhunter (Heavy Strike Fighter)"
+		"Headhunter (Strike)"
 	variant 3
 		"Aerie" 2
 		"Dagger" 4
@@ -1927,7 +1927,7 @@ fleet "Large Core Pirates"
 		"Fury (Bomber)"
 		"Quicksilver (Proton)" 2
 	variant 2
-		"Headhunter (Heavy Strike Fighter)"
+		"Headhunter (Strike)"
 		"Quicksilver" 2
 	variant 3
 		"Splinter (Proton)"
@@ -1979,7 +1979,7 @@ fleet "Small Northern Pirates"
 	variant 2
 		"Berserker (Afterburner)"
 	variant 2
-		"Berserker (Strike Fighter)"
+		"Berserker (Strike)"
 	variant 2
 		"Hawk"
 	variant 1
@@ -1994,7 +1994,7 @@ fleet "Small Northern Pirates"
 	variant 2
 		"Headhunter (Particle)"
 	variant 2
-		"Headhunter (Heavy Strike Fighter)"
+		"Headhunter (Strike)"
 	variant 2
 		"Raven (Afterburner)"
 	variant 1
@@ -2051,10 +2051,10 @@ fleet "Large Northern Pirates"
 		"Raven (Heavy)" 2
 	variant 2
 		"Headhunter (Particle)" 1
-		"Headhunter (Heavy Strike Fighter)"
+		"Headhunter (Strike)"
 	variant 1
 		"Headhunter (Particle)" 2
-		"Headhunter (Heavy Strike Fighter)"
+		"Headhunter (Strike)"
 	variant 2
 		"Leviathan"
 		"Firebird"
@@ -2084,13 +2084,13 @@ fleet "Large Northern Pirates"
 	variant 1
 		"Berserker (Afterburner)" 3
 	variant 1
-		"Berserker (Strike Fighter)" 3
+		"Berserker (Strike)" 3
 	variant 2
 		"Berserker" 2
 	variant 2
 		"Berserker (Afterburner)" 2
 	variant 2
-		"Berserker (Strike Fighter)" 2
+		"Berserker (Strike)" 2
 	variant 1
 		"Bactrian"
 		"Dagger" 3
@@ -2275,14 +2275,14 @@ fleet "Bounty Hunters"
 		"Fury (Bomber)"
 		"Sparrow" 2
 	variant 5
-		"Berserker (Strike Fighter)"
+		"Berserker (Strike)"
 		"Quicksilver"
 	variant 5
 		"Quicksilver" 2
 		"Headhunter (Particle)"
 	variant 3
 		"Sparrow" 2
-		"Headhunter (Heavy Strike Fighter)"
+		"Headhunter (Strike)"
 	variant 3
 		"Raven"
 		"Fury (Missile)" 2
@@ -2841,7 +2841,7 @@ fleet "Hired Guns"
 		"Modified Argosy" 2
     variant 1
 		"Vanguard (Missile)"
-		"Headhunter (Heavy Strike Fighter)" 2
+		"Headhunter (Strike)" 2
 	variant 1
 		"Vanguard (Particle)"
 		"Mule (Heavy)"

--- a/data/fleets.txt
+++ b/data/fleets.txt
@@ -234,6 +234,10 @@ fleet "Large Core Merchants"
 	variant 50
 		"Bulk Freighter"
 		"Wasp (Proton)" 2
+    variant 50
+		"Bulk Freighter"
+		"Wasp"
+		"Wasp (Bomber)"
 	variant 20
 		"Bulk Freighter (Blaster)"
 		"Wasp" 2
@@ -243,6 +247,10 @@ fleet "Large Core Merchants"
 	variant 10
 		"Bulk Freighter (Proton)"
 		"Wasp (Proton)" 2
+    variant 10
+		"Bulk Freighter (Proton)"
+		"Wasp"
+		"Wasp (Bomber)"
 	variant 20
 		"Bulk Freighter"
 	variant 10
@@ -291,6 +299,10 @@ fleet "Large Core Merchants"
 	variant 10
 		"Bulk Freighter" 2
 		"Protector" 1
+    variant 10
+		"Bulk Freighter" 2
+		"Wasp" 3
+		"Wasp (Bomber)" 2
 	variant 10
 		"Bulk Freighter" 2
 		"Vanguard" 1
@@ -303,6 +315,9 @@ fleet "Large Core Merchants"
 	variant 1
 		"Bulk Freighter (Heavy)" 2
 		"Vanguard (Particle)" 1
+    variant 1
+		"Bulk Freighter (Heavy)" 2
+		"Vanguard (Missile)" 1
 	variant 20
 		"Bounder"
 		"Quicksilver" 2
@@ -341,6 +356,13 @@ fleet "Paradise Merchants"
 	variant 3
 		"Star Queen"
 		"Wasp (Proton)" 3
+    variant 2
+		"Star Queen"
+		"Wasp" 2
+		"Wasp (Bomber)"
+    variant 2
+		"Star Queen"
+		"Berserker" 3
 	variant 2
 		"Star Queen"
 		"Quicksilver" 2
@@ -399,6 +421,9 @@ fleet "Small Northern Merchants"
 	variant 3
 		"Freighter"
 		"Berserker (Afterburner)"
+	variant 3
+		"Freighter"
+		"Berserker (Strike Fighter)"
 	variant 5
 		"Freighter (Fancy)"
 		"Shuttle" 4
@@ -444,6 +469,9 @@ fleet "Large Northern Merchants"
 	variant 3
 		"Freighter" 2
 		"Berserker (Afterburner)" 2
+	variant 3
+		"Freighter" 2
+		"Berserker (Strike Fighter)" 2
 	variant 10
 		"Freighter" 2
 		"Firebird (Plasma)"
@@ -498,6 +526,9 @@ fleet "Large Northern Merchants"
 		"Behemoth (Speedy)"
 	variant 10
 		"Behemoth (Proton)"
+	variant 10
+		"Behemoth"
+		"Berserker (Strike Fighter)" 3
 	variant 10
 		"Behemoth" 2
 	variant 1
@@ -564,7 +595,7 @@ fleet "Large Northern Merchants"
 		"Headhunter (Particle)" 3
 	variant 1
 		"Star Queen"
-		"Berserker (Afterburner)" 2
+		"Berserker (Strike Fighter)" 2
 	variant 1
 		"Star Queen"
 		"Leviathan (Heavy)"
@@ -844,6 +875,9 @@ fleet "Small Free Worlds"
 		"Hawk"
 		"Fury (Missile)"
 	variant 2
+		"Fury (Bomber)"
+		"Sparrow"
+	variant 2
 		"Hawk"
 		"Fury (Laser)"
 	variant 4
@@ -858,7 +892,11 @@ fleet "Small Free Worlds"
 	variant 1
 		"Hawk (Rocket)"
 	variant 1
+		"Hawk (Plasma)"
+	variant 1
 		"Hawk (Speedy)"
+    variant 1
+		"Hawk (Bomber)"
 	variant 2
 		"Sparrow"
 	variant 2
@@ -871,6 +909,15 @@ fleet "Small Free Worlds"
 		"Sparrow" 2
 	variant 2
 		"Hawk (Speedy)"
+		"Sparrow" 2
+    variant 2
+		"Hawk (Bomber)"
+		"Sparrow" 2
+	variant 2
+		"Fury (Bomber)"
+		"Sparrow" 2
+	variant 2
+		"Hawk (Plasma)"
 		"Sparrow" 2
 
 fleet "Large Free Worlds"
@@ -938,7 +985,8 @@ fleet "Large Free Worlds"
 		"Sparrow" 3
 	variant 1
 		"Falcon (Laser)"
-		"Hawk" 2
+		"Hawk"
+		"Hawk (Plasma)"
 		"Sparrow" 3
 	variant 4
 		"Falcon"
@@ -948,10 +996,36 @@ fleet "Large Free Worlds"
 		"Falcon (Heavy)"
 		"Bastion (Heavy)"
 		"Hawk (Rocket)"
+    variant 2
+		"Hawk (Rocket)" 2
+		"Sparrow" 4
+    variant 2
+		"Falcon (Heavy)"
+		"Bastion (Heavy)"
+		"Hawk (Bomber)"
 	variant 2
 		"Falcon (Laser)"
 		"Bastion (Laser)"
 		"Hawk (Speedy)"
+    variant 2
+		"Falcon (Laser)"
+		"Bastion (Laser)"
+		"Hawk (Bomber)"
+	variant 2
+		"Bastion (Heavy)"
+		"Fury (Bomber)" 2
+		"Sparrow" 2
+	variant 2
+		"Falcon (Heavy)"
+		"Fury (Bomber)" 2
+		"Sparrow" 4
+	variant 1
+		"Hawk" 4
+	variant 1
+		"Hawk (Plasma)" 4
+	variant 1
+		"Hawk (Plasma)" 2
+		"Hawk (Bomber)" 2
 
 fleet "Small Militia"
 	government "Militia"
@@ -972,6 +1046,12 @@ fleet "Small Militia"
 	variant 2
 		"Hawk"
 		"Fury (Laser)"
+	variant 2
+		"Hawk"
+		"Fury (Bomber)"
+	variant 2
+		"Fury (Bomber)"
+		"Sparrow"
 	variant 4
 		"Fury" 2
 	variant 2
@@ -997,6 +1077,9 @@ fleet "Small Militia"
 		"Sparrow" 2
 	variant 2
 		"Hawk (Speedy)"
+		"Sparrow" 2
+	variant 2
+		"Fury (Bomber)"
 		"Sparrow" 2
 
 fleet "Large Militia"
@@ -1168,6 +1251,8 @@ fleet "Small Deep Merchants"
 		"Raven (Heavy)"
 	variant 3
 		"Headhunter"
+	variant 1
+		"Headhunter (Heavy Strike Fighter)"
 	variant 3
 		"Flivver"
 	variant 2
@@ -1229,6 +1314,10 @@ fleet "Large Deep Merchants"
 		"Headhunter" 2
 	variant 1
 		"Star Queen"
+		"Headhunter (Particle)"
+		"Headhunter (Heavy Strike Fighter)"
+	variant 1
+		"Star Queen"
 		"Raven (Afterburner)" 2
 
 fleet "Small Deep Security"
@@ -1251,6 +1340,8 @@ fleet "Small Deep Security"
 		"Headhunter"
 	variant 2
 		"Headhunter (Particle)"
+	variant 2
+		"Headhunter (Heavy Strike Fighter)"
 	variant 4
 		"Corvette"
 	variant 2
@@ -1297,6 +1388,9 @@ fleet "Large Deep Security"
 		"Headhunter" 2
 	variant 2
 		"Headhunter (Particle)" 2
+	variant 2
+		"Headhunter (Particle)"
+		"Headhunter (Heavy Strike Fighter)"
 	variant 3
 		"Aerie" 2
 		"Dagger" 4
@@ -1448,6 +1542,8 @@ fleet "Large Syndicate"
 		"Protector"
 	variant 1
 		"Vanguard"
+    variant 1
+		"Vanguard (Missile)"
 	variant 1
 		"Protector (Laser)"
 	variant 1
@@ -1467,6 +1563,9 @@ fleet "Large Syndicate"
 	variant 1
 		"Vanguard"
 		"Quicksilver (Proton)" 2
+    variant 1
+		"Vanguard (Missile)"
+		"Quicksilver (Proton)" 2
 
 fleet "Small Southern Pirates"
 	government "Pirate"
@@ -1485,13 +1584,17 @@ fleet "Small Southern Pirates"
 		"Hawk (Rocket)"
 	variant 5
 		"Fury"
+	variant 4
+		"Fury (Bomber)"
 	variant 1
 		"Fury (Laser)"
 	variant 1
 		"Fury (Gatling)"
 	variant 1
 		"Fury (Missile)"
-	variant 2
+    variant 1
+		"Fury (Heavy)"
+	variant 4
 		"Sparrow" 2
 	variant 1
 		"Hawk"
@@ -1503,6 +1606,8 @@ fleet "Small Southern Pirates"
 		"Fury" 3
 	variant 1
 		"Fury (Missile)" 3
+    variant 1
+		"Fury (Heavy)" 2
 	variant 1
 		"Fury"
 		"Hawk"
@@ -1516,6 +1621,9 @@ fleet "Small Southern Pirates"
 		"Sparrow"
 	variant 1
 		"Sparrow" 3
+	variant 1
+		"Fury (Bomber)"
+		"Sparrow"
 	variant 1
 		"Hawk" 2
 	variant 1
@@ -1569,9 +1677,21 @@ fleet "Large Southern Pirates"
 	variant 1
 		"Clipper (Heavy)"
 		"Hawk (Rocket)"
+    variant 2
+		"Hawk (Bomber)"
+		"Sparrow" 3
+	variant 2
+		"Fury (Bomber)"
+		"Sparrow" 3
 	variant 1
 		"Clipper (Speedy)"
 		"Hawk (Speedy)"
+    variant 1
+		"Hawk (Bomber)"
+		"Fury (Gatling)" 2
+	variant 1
+		"Fury (Bomber)"
+		"Fury (Gatling)" 2
 	variant 3
 		"Argosy"
 		"Hawk"
@@ -1598,6 +1718,9 @@ fleet "Large Southern Pirates"
 		"Sparrow" 2
 	variant 1
 		"Modified Argosy (Missile)" 2
+    variant 1
+		"Fury (Heavy)" 2
+		"Modified Argosy (Missile)"
 	variant 4
 		"Bastion"
 	variant 2
@@ -1606,6 +1729,9 @@ fleet "Large Southern Pirates"
 		"Bastion (Laser)"
 	variant 2
 		"Falcon"
+    variant 1
+		"Falcon"
+		"Sparrow" 3
 	variant 1
 		"Falcon (Heavy)"
 	variant 1
@@ -1749,6 +1875,8 @@ fleet "Small Core Pirates"
 	variant 4
 		"Fury"
 	variant 2
+		"Fury (Bomber)"
+	variant 2
 		"Fury (Laser)"
 	variant 1
 		"Fury (Missile)"
@@ -1758,6 +1886,14 @@ fleet "Small Core Pirates"
 		"Headhunter (Particle)"
 	variant 2
 		"Quicksilver" 2
+    variant 1
+		"Hawk (Bomber)"
+		"Sparrow"
+	variant 1
+		"Fury (Bomber)"
+		"Sparrow"
+    variant 1
+		"Fury (Heavy)"
 
 fleet "Large Core Pirates"
 	government "Pirate"
@@ -1775,6 +1911,24 @@ fleet "Large Core Pirates"
 	variant 3
 		"Splinter (Laser)"
 		"Quicksilver"
+    variant 2
+		"Hawk (Bomber)"
+		"Quicksilver" 2
+    variant 1
+		"Fury (Heavy)"
+		"Splinter"
+    variant 2
+		"Hawk (Bomber)"
+		"Quicksilver (Proton)" 2
+	variant 3
+		"Fury (Bomber)"
+		"Quicksilver" 2
+    variant 3
+		"Fury (Bomber)"
+		"Quicksilver (Proton)" 2
+	variant 2
+		"Headhunter (Heavy Strike Fighter)"
+		"Quicksilver" 2
 	variant 3
 		"Splinter (Proton)"
 		"Quicksilver"
@@ -1816,20 +1970,31 @@ fleet "Small Northern Pirates"
 		"Fury (Missile)"
 	variant 1
 		"Fury (Laser)"
+	variant 1
+		"Fury (Bomber)"
+    variant 1
+		"Fury (Heavy)"
 	variant 2
 		"Berserker"
 	variant 2
 		"Berserker (Afterburner)"
+	variant 2
+		"Berserker (Strike Fighter)"
 	variant 2
 		"Hawk"
 	variant 1
 		"Hawk (Rocket)"
 	variant 1
 		"Hawk (Speedy)"
+    variant 1
+		"Hawk (Bomber)"
+		"Sparrow"
 	variant 3
 		"Headhunter"
 	variant 2
 		"Headhunter (Particle)"
+	variant 2
+		"Headhunter (Heavy Strike Fighter)"
 	variant 2
 		"Raven (Afterburner)"
 	variant 1
@@ -1877,14 +2042,19 @@ fleet "Large Northern Pirates"
 	variant 1
 		"Firebird (Plasma)"
 		"Fury (Missile)"
+	variant 1
+		"Firebird (Missile)"
+		"Fury (Bomber)"
 	variant 2
 		"Raven (Afterburner)" 2
 	variant 2
 		"Raven (Heavy)" 2
 	variant 2
-		"Headhunter (Particle)" 2
+		"Headhunter (Particle)" 1
+		"Headhunter (Heavy Strike Fighter)"
 	variant 1
-		"Headhunter (Particle)" 3
+		"Headhunter (Particle)" 2
+		"Headhunter (Heavy Strike Fighter)"
 	variant 2
 		"Leviathan"
 		"Firebird"
@@ -1908,12 +2078,19 @@ fleet "Large Northern Pirates"
 		"Leviathan (Heavy)"
 	variant 1
 		"Berserker" 3
+    variant 1
+		"Fury (Heavy)" 2
+		"Firebird (Missile)"
 	variant 1
 		"Berserker (Afterburner)" 3
+	variant 1
+		"Berserker (Strike Fighter)" 3
 	variant 2
 		"Berserker" 2
 	variant 2
 		"Berserker (Afterburner)" 2
+	variant 2
+		"Berserker (Strike Fighter)" 2
 	variant 1
 		"Bactrian"
 		"Dagger" 3
@@ -1947,6 +2124,10 @@ fleet "pirate raid"
 		"Hawk (Speedy)"
 	variant 6
 		"Hawk (Speedy)" 3
+    variant 4
+		"Hawk (Bomber)" 2
+	variant 4
+		"Fury (Bomber)" 2
 	variant 1
 		"Argosy (Blaster)"
 		"Hawk (Rocket)"
@@ -2014,12 +2195,18 @@ fleet "pirate raid"
 	variant 1
 		"Firebird (Plasma)"
 		"Fury (Missile)"
+	variant 1
+		"Firebird (Missile)"
+		"Fury (Bomber)"
 	variant 8
 		"Raven (Afterburner)" 2
 	variant 2
 		"Raven (Heavy)" 2
 	variant 1
 		"Headhunter (Particle)" 3
+    variant 1
+		"Fury (Heavy)" 2
+		"Firebird (Missile)"
 	variant 2
 		"Leviathan"
 		"Firebird"
@@ -2056,6 +2243,9 @@ fleet "Syndicate Extremists"
 	variant 1
 		"Vanguard"
 		"Quicksilver" 2
+    variant 1
+		"Vanguard (Missile)"
+		"Quicksilver (Proton)" 2
 	variant 1
 		"Leviathan"
 		"Firebird" 2
@@ -2073,13 +2263,26 @@ fleet "Bounty Hunters"
 		nemesis waiting heroic
 	variant 5
 		"Fury" 2
-		"Fury (Missile)" 2
+		"Fury (Bomber)" 2
 	variant 5
 		"Hawk" 2
 		"Hawk (Rocket)" 2
+    variant 5
+		"Hawk"
+		"Hawk (Bomber)"
+		"Sparrow" 2
+	variant 5
+		"Fury (Bomber)"
+		"Sparrow" 2
+	variant 5
+		"Berserker (Strike Fighter)"
+		"Quicksilver"
 	variant 5
 		"Quicksilver" 2
 		"Headhunter (Particle)"
+	variant 3
+		"Sparrow" 2
+		"Headhunter (Heavy Strike Fighter)"
 	variant 3
 		"Raven"
 		"Fury (Missile)" 2
@@ -2088,7 +2291,7 @@ fleet "Bounty Hunters"
 		"Fury (Missile)"
 	variant 1
 		"Aerie"
-		"Fury (Missile)"
+		"Lance" 2
 	variant 1
 		"Corvette"
 		"Fury (Missile)"
@@ -2101,6 +2304,9 @@ fleet "Bounty Hunters"
 	variant 1
 		"Splinter"
 		"Fury (Missile)"
+    variant 1
+		"Splinter"
+		"Fury (Heavy)"
 
 fleet "Quarg"
 	government "Quarg"
@@ -2633,6 +2839,9 @@ fleet "Hired Guns"
 	variant 1
 		"Vanguard (Particle)"
 		"Modified Argosy" 2
+    variant 1
+		"Vanguard (Missile)"
+		"Headhunter (Heavy Strike Fighter)" 2
 	variant 1
 		"Vanguard (Particle)"
 		"Mule (Heavy)"

--- a/data/fleets.txt
+++ b/data/fleets.txt
@@ -477,6 +477,9 @@ fleet "Large Northern Merchants"
 		"Firebird (Plasma)"
 	variant 10
 		"Freighter" 2
+		"Firebird (Laser)"
+	variant 10
+		"Freighter" 2
 		"Firebird (Missile)"
 	variant 10
 		"Freighter" 3
@@ -484,6 +487,9 @@ fleet "Large Northern Merchants"
 	variant 2
 		"Freighter" 3
 		"Firebird (Plasma)"
+	variant 2
+		"Freighter" 3
+		"Firebird (Laser)"
 	variant 2
 		"Freighter" 3
 		"Firebird (Missile)"
@@ -605,6 +611,9 @@ fleet "Large Northern Merchants"
 	variant 1
 		"Star Queen"
 		"Firebird" 2
+	variant 2
+		"Star Queen"
+		"Firebird (Laser)" 2
 	variant 1
 		"Star Queen"
 		"Firebird (Plasma)" 2
@@ -1950,6 +1959,8 @@ fleet "Large Core Pirates"
 		"Falcon (Laser)"
 	variant 2
 		"Firebird"
+	variant 2
+		"Firebird (Laser)"
 	variant 1
 		"Firebird (Plasma)"
 	variant 1
@@ -2014,6 +2025,8 @@ fleet "Large Northern Pirates"
 		plunders harvests
 	variant 4
 		"Firebird"
+	variant 3
+		"Firebird (Laser)"
 	variant 2
 		"Firebird (Missile)"
 	variant 2
@@ -2029,6 +2042,9 @@ fleet "Large Northern Pirates"
 		"Corvette (Missile)"
 	variant 1
 		"Firebird (Plasma)"
+		"Corvette (Missile)"
+	variant 1
+		"Firebird (Laser)"
 		"Corvette (Missile)"
 	variant 1
 		"Firebird (Missile)"
@@ -2061,6 +2077,9 @@ fleet "Large Northern Pirates"
 	variant 2
 		"Leviathan (Laser)"
 		"Firebird"
+	variant 2
+		"Leviathan (Laser)"
+		"Firebird (Laser)"
 	variant 2
 		"Leviathan (Heavy)"
 		"Firebird (Plasma)"
@@ -2178,9 +2197,13 @@ fleet "pirate raid"
 	variant 2
 		"Firebird"
 	variant 1
+		"Firebird (Laser)"
+	variant 1
 		"Firebird (Plasma)"
 	variant 4
 		"Firebird"
+	variant 2
+		"Firebird (Laser)"
 	variant 2
 		"Firebird (Plasma)"
 	variant 3
@@ -2667,6 +2690,9 @@ fleet "Marauder fleet VII"
 		"Firebird"
 		"Firebird (Plasma)"
 		"Firebird (Missile)"
+	variant 1
+		"Marauder Leviathan (Weapons)"
+		"Firebird (Laser)" 3
 
 fleet "Marauder fleet VIII"
 	government "Pirate"
@@ -2740,6 +2766,10 @@ fleet "Marauder fleet IX"
 		"Marauder Leviathan (Weapons)"
 		"Firebird"
 		"Firebird (Plasma)"
+		"Firebird (Missile)"
+	variant 1
+		"Marauder Leviathan (Weapons)"
+		"Firebird (Laser)" 3
 		"Firebird (Missile)"
 
 fleet "Marauder fleet X"

--- a/data/jobs.txt
+++ b/data/jobs.txt
@@ -1071,7 +1071,7 @@ mission "Escort (Tiny, Southern, Dangerous Origin or Destination)"
 			variant
 				"Fury"
 			variant
-				"hawk"
+				"Hawk"
 	npc
 		government Pirate
 		personality nemesis staying harvests plunders

--- a/data/jobs.txt
+++ b/data/jobs.txt
@@ -37,7 +37,7 @@ mission "Escort (Tiny, Northern, Dangerous Destination)"
 			variant
 				"Sparrow"
 			variant
-				"Wasp"
+				"Fury"
 			variant
 				"Berserker"
 	npc
@@ -50,7 +50,7 @@ mission "Escort (Tiny, Northern, Dangerous Destination)"
 			variant
 				"Sparrow"
 			variant
-				"Wasp"
+				"Fury"
 			variant
 				"Berserker"
 	
@@ -97,7 +97,7 @@ mission "Escort (Tiny, Northern, Dangerous Origin)"
 			variant
 				"Sparrow"
 			variant
-				"Wasp"
+				"Fury"
 			variant
 				"Berserker"
 	npc
@@ -111,7 +111,7 @@ mission "Escort (Tiny, Northern, Dangerous Origin)"
 			variant
 				"Sparrow"
 			variant
-				"Wasp"
+				"Fury"
 			variant
 				"Berserker"
 	
@@ -555,7 +555,7 @@ mission "Escort (Tiny, Core, Dangerous Destination)"
 			variant
 				"Sparrow"
 			variant
-				"Wasp"
+				"Fury"
 			variant
 				"Berserker"
 	npc
@@ -568,7 +568,7 @@ mission "Escort (Tiny, Core, Dangerous Destination)"
 			variant
 				"Sparrow"
 			variant
-				"Wasp"
+				"Fury"
 			variant
 				"Berserker"
 	
@@ -617,7 +617,7 @@ mission "Escort (Tiny, Core, Dangerous Origin)"
 			variant
 				"Sparrow"
 			variant
-				"Wasp"
+				"Fury"
 			variant
 				"Berserker"
 	npc
@@ -629,7 +629,7 @@ mission "Escort (Tiny, Core, Dangerous Origin)"
 			variant
 				"Sparrow"
 			variant
-				"Wasp"
+				"Fury"
 			variant
 				"Berserker"
 	
@@ -1069,9 +1069,9 @@ mission "Escort (Tiny, Southern, Dangerous Origin or Destination)"
 			variant
 				"Sparrow"
 			variant
-				"Wasp"
+				"Fury"
 			variant
-				"Berserker"
+				"hawk"
 	npc
 		government Pirate
 		personality nemesis staying harvests plunders
@@ -1082,9 +1082,9 @@ mission "Escort (Tiny, Southern, Dangerous Origin or Destination)"
 			variant
 				"Sparrow"
 			variant
-				"Wasp"
+				"Fury"
 			variant
-				"Berserker"
+				"Hawk"
 	
 	npc accompany save
 		government Merchant

--- a/data/ships.txt
+++ b/data/ships.txt
@@ -1299,7 +1299,7 @@ ship "Firebird"
 		"Particle Cannon" 2
 		"Meteor Missile Launcher" 2
 		"Meteor Missile" 70
-		"Heavy Laser Turret"
+		"Quad Blaster Turret"
 		"Anti-Missile Turret"
 		
 		"RT-I Radiothermal"
@@ -1318,7 +1318,7 @@ ship "Firebird"
 	gun -39 -13 "Meteor Missile Launcher"
 	gun 39 -13 "Meteor Missile Launcher"
 	turret -5 3 "Anti-Missile Turret"
-	turret 5 3 "Heavy Laser Turret"
+	turret 5 3 "Quad Blaster Turret"
 	leak "leak" 50 50
 	leak "flame" 30 80
 	explode "tiny explosion" 18
@@ -2251,7 +2251,7 @@ ship "Osprey"
 	thumbnail "thumbnail/osprey"
 	attributes
 		category "Medium Warship"
-		"cost" 3400000
+		"cost" 4400000
 		"shields" 7200
 		"hull" 1600
 		"required crew" 9

--- a/data/ships.txt
+++ b/data/ships.txt
@@ -32,7 +32,8 @@ ship "Aerie"
 			"hull damage" 400
 			"hit force" 1200
 	outfits
-		"Heavy Laser" 2
+		"Sidewinder Missile Launcher" 2
+		"Sidewinder Missile" 100
 		"Heavy Laser Turret" 2
 		"Heavy Anti-Missile Turret"
 		
@@ -47,8 +48,8 @@ ship "Aerie"
 		
 	engine -10 91
 	engine 10 91
-	gun -13 -79 "Heavy Laser"
-	gun 13 -79 "Heavy Laser"
+	gun -13 -79 "Sidewinder Missile Launcher"
+	gun 13 -79 "Sidewinder Missile Launcher"
 	turret 0 0 "Heavy Anti-Missile Turret"
 	turret -17 14 "Heavy Laser Turret"
 	turret 17 14 "Heavy Laser Turret"
@@ -94,7 +95,8 @@ ship "Argosy"
 		"Energy Blaster" 2
 		"Meteor Missile Launcher" 2
 		"Meteor Missile" 70
-		"Blaster Turret" 2
+		"Blaster Turret"
+		"Anti-Missile Turret"
 		
 		"RT-I Radiothermal"
 		"LP072a Battery Pack"
@@ -111,7 +113,7 @@ ship "Argosy"
 	gun -23 -37 "Meteor Missile Launcher"
 	gun 23 -37 "Meteor Missile Launcher"
 	turret 0 -12 "Blaster Turret"
-	turret 0 8 "Blaster Turret"
+	turret 0 8 "Anti-Missile Turret"
 	leak "leak" 60 50
 	leak "flame" 60 80
 	explode "tiny explosion" 10
@@ -352,7 +354,8 @@ ship "Bastion"
 		"Plasma Cannon" 2
 		"Heavy Rocket Launcher" 2
 		"Heavy Rocket" 40
-		"Blaster Turret" 3
+		"Blaster Turret" 2
+		"Anti-Missile Turret"
 		
 		"S3 Thermionic"
 		"LP144a Battery Pack"
@@ -370,7 +373,7 @@ ship "Bastion"
 	gun 54 -14 "Plasma Cannon"
 	gun -54 -14 "Heavy Rocket Launcher"
 	gun 54 -14 "Heavy Rocket Launcher"
-	turret 0 0 "Blaster Turret"
+	turret 0 0 "Anti-Missile Turret"
 	turret -30 14 "Blaster Turret"
 	turret 30 14 "Blaster Turret"
 	leak "leak" 40 50
@@ -467,7 +470,9 @@ ship "Berserker"
 			"hull damage" 150
 			"hit force" 450
 	outfits
-		"Beam Laser" 4
+		"Energy Blaster" 2
+		"Javelin Pod" 2
+		"Javelin" 400
 		
 		"nGVF-CC Fuel Cell"
 		"LP072a Battery Pack"
@@ -479,10 +484,10 @@ ship "Berserker"
 		
 	engine -10 45
 	engine 10 45
-	gun -20 12
-	gun 20 12
-	gun -44 10
-	gun 44 10
+	gun -20 12 "Energy Blaster"
+	gun 20 12 "Energy Blaster"
+	gun -44 10 "Javelin Pod"
+	gun 44 10 "Javelin Pod"
 	leak "leak" 60 50
 	leak "flame" 80 80
 	explode "tiny explosion" 10
@@ -516,7 +521,8 @@ ship "Blackbird"
 			"hull damage" 300
 			"hit force" 900
 	outfits
-		"Heavy Laser Turret" 2
+		"Heavy Laser Turret"
+		"Heavy Anti-Missile Turret"
 		
 		"S3 Thermionic"
 		"LP072a Battery Pack"
@@ -530,7 +536,7 @@ ship "Blackbird"
 	engine -40 55
 	engine 40 55
 	turret -18 0 "Heavy Laser Turret"
-	turret 18 0 "Heavy Laser Turret"
+	turret 18 0 "Heavy Anti-Missile Turret"
 	leak "leak" 50 50
 	leak "flame" 70 80
 	explode "tiny explosion" 15
@@ -538,7 +544,7 @@ ship "Blackbird"
 	explode "medium explosion" 18
 	explode "large explosion" 2
 	"final explode" "final explosion small"
-	description "The Tarazed Blackbird is a high-class passenger transport, designed to move large numbers of people across the galaxy with speed and safety. Although not equipped with much weaponry, a Blackbird is well shielded and fast enough to evade pirate attacks, and its cargo capacity is high enough to allow the captain to take courier missions on the side."
+	description "The Tarazed Blackbird is a high-class passenger transport, designed to move large numbers of people across the galaxy with speed and safety. Although not equipped with much weaponry, a Blackbird is well protected and fast enough to evade pirate attacks, and its cargo capacity is high enough to allow the captain to take courier missions on the side."
 
 
 
@@ -566,7 +572,7 @@ ship "Bounder"
 			"hull damage" 150
 			"hit force" 450
 	outfits
-		"Blaster Turret" 2
+		"Anti-Missile Turret" 2
 		
 		"nGVF-CC Fuel Cell"
 		"LP036a Battery Pack"
@@ -578,8 +584,8 @@ ship "Bounder"
 		
 	engine -12 44
 	engine 12 44
-	turret -37 4 "Blaster Turret"
-	turret 37 4 "Blaster Turret"
+	turret -37 4 "Anti-Missile Turret"
+	turret 37 4 "Anti-Missile Turret"
 	leak "leak" 60 50
 	explode "tiny explosion" 10
 	explode "small explosion" 20
@@ -714,13 +720,13 @@ ship "Carrier"
 		"Particle Cannon" 4
 		"Meteor Missile Launcher" 4
 		"Meteor Missile" 140
-		"Heavy Laser Turret" 3
-		"Heavy Anti-Missile Turret"
+		"Heavy Laser Turret" 2
+		"Heavy Anti-Missile Turret" 2
 		
 		"Fusion Reactor"
 		"LP288a Battery Pack"
 		"D94-YV Shield Generator"
-		"Large Radar Jammer"
+		"Large Radar Jammer" 2
 		"Water Coolant System"
 		
 		"X5700 Ion Thruster"
@@ -738,7 +744,7 @@ ship "Carrier"
 	gun -25 -166 "Meteor Missile Launcher"
 	gun 25 -166 "Meteor Missile Launcher"
 	turret 0 -114 "Heavy Laser Turret"
-	turret 0 15 "Heavy Laser Turret"
+	turret 0 15 "Heavy Anti-Missile Turret"
 	turret 0 103 "Heavy Anti-Missile Turret"
 	turret 0 157 "Heavy Laser Turret"
 	fighter -37 -65
@@ -943,8 +949,11 @@ ship "Corvette"
 			"hull damage" 400
 			"hit force" 1200
 	outfits
-		"Heavy Laser" 4
-		"Heavy Laser Turret" 2
+		"Heavy Laser" 2
+		"Sidewinder Missile Launcher" 2
+		"Sidewinder Missile" 100
+		"Heavy Laser Turret"
+		"Anti-Missile Turret"
 		
 		"NT-200 Nucleovoltaic"
 		"LP072a Battery Pack"
@@ -959,10 +968,10 @@ ship "Corvette"
 	engine 11 118
 	gun -12 -68 "Heavy Laser"
 	gun 12 -68 "Heavy Laser"
-	gun -14 -60 "Heavy Laser"
-	gun 14 -60 "Heavy Laser"
+	gun -14 -60 "Sidewinder Missile Launcher"
+	gun 14 -60 "Sidewinder Missile Launcher"
 	turret 0 -11 "Heavy Laser Turret"
-	turret 0 74 "Heavy Laser Turret"
+	turret 0 74 "Anti-Missile Turret"
 	leak "leak" 40 50
 	leak "flame" 50 80
 	leak "big leak" 90 30
@@ -1005,13 +1014,13 @@ ship "Cruiser"
 		"Particle Cannon" 4
 		"Sidewinder Missile Launcher" 2
 		"Sidewinder Missile" 100
-		"Heavy Laser Turret" 3
-		"Heavy Anti-Missile Turret"
+		"Heavy Laser Turret" 2
+		"Heavy Anti-Missile Turret" 2
 		
 		"Fusion Reactor"
 		"LP288a Battery Pack"
 		"D67-TM Shield Generator"
-		"Large Radar Jammer"
+		"Large Radar Jammer" 2
 		"Liquid Nitrogen Cooler"
 		
 		"X4700 Ion Thruster"
@@ -1026,7 +1035,7 @@ ship "Cruiser"
 	gun 41 -52 "Particle Cannon"
 	gun -20 -44 "Sidewinder Missile Launcher"
 	gun 20 -44 "Sidewinder Missile Launcher"
-	turret 0 -40 "Heavy Laser Turret"
+	turret 0 -40 "Heavy Anti-Missile Turret"
 	turret -33 -19 "Heavy Laser Turret"
 	turret 33 -19 "Heavy Laser Turret"
 	turret 0 0 "Heavy Anti-Missile Turret"
@@ -1069,10 +1078,14 @@ ship "Dagger"
 			"hull damage" 60
 			"hit force" 180
 	outfits
-		"Beam Laser" 2
+		"Beam Laser"
+		"Javelin Pod"
+		"Javelin" 200
 		
-		"nGVF-BB Fuel Cell"
+		"nGVF-AA Fuel Cell"
+		"Supercapacitor"
 		"D14-RN Shield Generator"
+		"Small Radar Jammer"
 		
 		"X1700 Ion Thruster"
 		"X1200 Ion Steering"
@@ -1080,7 +1093,7 @@ ship "Dagger"
 	engine -15 30
 	engine 15 30
 	gun -14 -10 "Beam Laser"
-	gun 14 -10 "Beam Laser"
+	gun 14 -10 "Javelin Pod"
 	leak "leak" 60 50
 	explode "tiny explosion" 15
 	explode "small explosion" 5
@@ -1112,9 +1125,10 @@ ship "Dreadnought"
 			"hull damage" 1300
 			"hit force" 3900
 	outfits
-		"Meteor Missile Launcher" 4
-		"Meteor Missile" 140
-		"Plasma Turret" 5
+		"Torpedo Launcher" 4
+		"Torpedo" 120
+		"Plasma Turret" 3
+		"Heavy Anti-Missile Turret" 2
 		
 		"Breeder Reactor"
 		"S3 Thermionic"
@@ -1129,13 +1143,13 @@ ship "Dreadnought"
 		
 	engine -25 172
 	engine 25 172
-	gun -10 -167 "Meteor Missile Launcher"
-	gun 10 -167 "Meteor Missile Launcher"
-	gun -20 -151 "Meteor Missile Launcher"
-	gun 20 -151 "Meteor Missile Launcher"
+	gun -10 -167 "Torpedo Launcher"
+	gun 10 -167 "Torpedo Launcher"
+	gun -20 -151 "Torpedo Launcher"
+	gun 20 -151 "Torpedo Launcher"
 	turret 0 -94 "Plasma Turret"
-	turret -38 -56 "Plasma Turret"
-	turret 38 -56 "Plasma Turret"
+	turret -38 -56 "Heavy Anti-Missile Turret"
+	turret 38 -56 "Heavy Anti-Missile Turret"
 	turret -44 118 "Plasma Turret"
 	turret 44 118 "Plasma Turret"
 	leak "leak" 40 50
@@ -1178,7 +1192,8 @@ ship "Falcon"
 		"Plasma Cannon" 2
 		"Torpedo Launcher" 2
 		"Torpedo" 60
-		"Quad Blaster Turret" 4
+		"Quad Blaster Turret" 3
+		"Heavy Anti-Missile Turret"
 		
 		"Breeder Reactor"
 		"LP144a Battery Pack"
@@ -1196,7 +1211,7 @@ ship "Falcon"
 	gun 17 -88 "Plasma Cannon"
 	gun -17 -88 "Torpedo Launcher"
 	gun 17 -88 "Torpedo Launcher"
-	turret -16 -24 "Quad Blaster Turret"
+	turret -16 -24 "Heavy Anti-Missile Turret"
 	turret 16 -24 "Quad Blaster Turret"
 	turret -57 40 "Quad Blaster Turret"
 	turret 57 40 "Quad Blaster Turret"
@@ -1235,7 +1250,9 @@ ship "Finch"
 			"hull damage" 60
 			"hit force" 180
 	outfits
-		"Beam Laser" 2
+		"Beam Laser"
+		"Javelin Pod"
+		"Javelin" 200
 		
 		"nGVF-BB Fuel Cell"
 		"LP036a Battery Pack"
@@ -1247,7 +1264,7 @@ ship "Finch"
 	engine -5 32
 	engine 5 32
 	gun -7 -14 "Beam Laser"
-	gun 7 -14 "Beam Laser"
+	gun 7 -14 "Javelin Pod"
 	leak "flame" 60 80
 	explode "tiny explosion" 15
 	explode "small explosion" 5
@@ -1279,8 +1296,11 @@ ship "Firebird"
 			"hull damage" 500
 			"hit force" 1500
 	outfits
-		"Heavy Laser" 4
-		"Heavy Laser Turret" 2
+		"Particle Cannon" 2
+		"Meteor Missile Launcher" 2
+		"Meteor Missile" 70
+		"Heavy Laser Turret"
+		"Anti-Missile Turret"
 		
 		"RT-I Radiothermal"
 		"nGVF-AA Fuel Cell"
@@ -1293,11 +1313,11 @@ ship "Firebird"
 		
 	engine -33 65
 	engine 33 65
-	gun -28 -27 "Heavy Laser"
-	gun 28 -27 "Heavy Laser"
-	gun -39 -13 "Heavy Laser"
-	gun 39 -13 "Heavy Laser"
-	turret -5 3 "Heavy Laser Turret"
+	gun -28 -27 "Particle Cannon"
+	gun 28 -27 "Particle Cannon"
+	gun -39 -13 "Meteor Missile Launcher"
+	gun 39 -13 "Meteor Missile Launcher"
+	turret -5 3 "Anti-Missile Turret"
 	turret 5 3 "Heavy Laser Turret"
 	leak "leak" 50 50
 	leak "flame" 30 80
@@ -1436,11 +1456,13 @@ ship "Frigate"
 		"Particle Cannon" 2
 		"Torpedo Launcher" 2
 		"Torpedo" 60
-		"Blaster Turret" 3
+		"Blaster Turret" 2
+		"Anti-Missile Turret"
 		
 		"NT-200 Nucleovoltaic"
 		"LP144a Battery Pack"
 		"D41-HY Shield Generator"
+		"Large Radar Jammer"
 		
 		"X3700 Ion Thruster"
 		"X3200 Ion Steering"
@@ -1452,7 +1474,7 @@ ship "Frigate"
 	gun 10 -83 "Particle Cannon"
 	gun -10 -83 "Torpedo Launcher"
 	gun 10 -83 "Torpedo Launcher"
-	turret 0 -37 "Blaster Turret"
+	turret 0 -37 "Anti-Missile Turret"
 	turret -12 -12 "Blaster Turret"
 	turret 12 -12 "Blaster Turret"
 	leak "leak" 40 50
@@ -1492,11 +1514,14 @@ ship "Fury"
 			"hull damage" 120
 			"hit force" 360
 	outfits
-		"Energy Blaster" 4
+		"Energy Blaster" 2
+		"Meteor Missile Launcher" 2
+		"Meteor Missile" 70
 		
-		"nGVF-CC Fuel Cell"
+		"nGVF-BB Fuel Cell"
 		"LP036a Battery Pack"
 		"D14-RN Shield Generator"
+		"Small Radar Jammer" 2
 		
 		"X2700 Ion Thruster"
 		"X2200 Ion Steering"
@@ -1504,10 +1529,10 @@ ship "Fury"
 		
 	engine -17 35
 	engine 17 35
-	gun -10 -26
-	gun 10 -26
-	gun -16 -20
-	gun 16 -20
+	gun -10 -26 "Energy Blaster"
+	gun 10 -26 "Energy Blaster"
+	gun -16 -20 "Meteor Missile Launcher"
+	gun 16 -20 "Meteor Missile Launcher"
 	leak "flame" 50 80
 	explode "tiny explosion" 10
 	explode "small explosion" 20
@@ -1547,6 +1572,7 @@ ship "Gunboat"
 		"RT-I Radiothermal"
 		"LP144a Battery Pack"
 		"D14-RN Shield Generator"
+		"Small Radar Jammer"
 		"Cargo Scanner"
 		"Outfit Scanner"
 		
@@ -1757,9 +1783,9 @@ ship "Hawk"
 		"drag" 2.1
 		"heat dissipation" .8
 		"fuel capacity" 300
-		"cargo space" 30
+		"cargo space" 20
 		"outfit space" 200
-		"weapon capacity" 40
+		"weapon capacity" 50
 		"engine capacity" 70
 		weapon
 			"blast radius" 30
@@ -1767,11 +1793,14 @@ ship "Hawk"
 			"hull damage" 150
 			"hit force" 450
 	outfits
-		"Heavy Laser" 2
+		"Heavy Laser"
+		"Heavy Rocket Launcher"
+		"Heavy Rocket" 20
 		
 		"nGVF-CC Fuel Cell"
 		"LP036a Battery Pack"
 		"D23-QP Shield Generator"
+		"Small Radar Jammer"
 		
 		"Greyhound Plasma Thruster"
 		"Greyhound Plasma Steering"
@@ -1779,13 +1808,13 @@ ship "Hawk"
 		
 	engine -24 41
 	engine 24 41
-	gun -9 -17
-	gun 9 -17
+	gun -9 -17 "Heavy Laser"
+	gun 9 -17 "Heavy Rocket Launcher"
 	leak "leak" 60 50
 	explode "tiny explosion" 15
 	explode "small explosion" 5
 	"final explode" "final explosion small"
-	description "The Tarazed Hawk is an interceptor-class warship often used as an escort for freighters or in a planetary militia's patrol squadron. Hawks are fast enough to chase down most smaller ships, while also being much more heavily armed and armored. They are also, of course, a favorite ship of pirate captains who have earned enough money to afford one."
+	description "The Tarazed Hawk is an interceptor-class warship often used as an escort for freighters or in a planetary militia's patrol squadron. Hawks are fast enough to chase down most smaller ships, but are capable of mounting much more powerful weapons. They are also, of course, a favorite ship of pirate captains who have earned enough money to afford one."
 
 
 
@@ -1904,19 +1933,22 @@ ship "Lance"
 			"hull damage" 60
 			"hit force" 180
 	outfits
-		"Beam Laser" 2
+		"Energy Blaster"
+		"Sidewinder Missile Launcher"
+		"Sidewinder Missile" 50
 		
 		"nGVF-AA Fuel Cell"
 		"LP036a Battery Pack"
 		"D14-RN Shield Generator"
+		"Small Radar Jammer" 2
 		
 		"X1700 Ion Thruster"
 		"X1200 Ion Steering"
 		
 	engine -15 30
 	engine 15 30
-	gun -14 -10 "Beam Laser"
-	gun 14 -10 "Beam Laser"
+	gun -14 -10 "Energy Blaster"
+	gun 14 -10 "Sidewinder Missile Launcher"
 	explode "tiny explosion" 15
 	explode "small explosion" 5
 	description "The Lance is the primary fighter used by the Republic Navy. As with all fighters, it is weak by itself but very effective as part of a larger squadron."
@@ -1948,7 +1980,8 @@ ship "Leviathan"
 			"hit force" 1200
 	outfits
 		"Particle Cannon" 4
-		"Quad Blaster Turret" 4
+		"Quad Blaster Turret" 3
+		"Anti-Missile Turret"
 		
 		"Fusion Reactor"
 		"LP144a Battery Pack"
@@ -1967,7 +2000,7 @@ ship "Leviathan"
 	gun 51 -21 "Particle Cannon"
 	turret -15 -50 "Quad Blaster Turret"
 	turret 15 -50 "Quad Blaster Turret"
-	turret -25 10 "Quad Blaster Turret"
+	turret -25 10 "Anti-Missile Turret"
 	turret 25 10 "Quad Blaster Turret"
 	leak "leak" 50 50
 	leak "flame" 30 80
@@ -2060,8 +2093,11 @@ ship "Modified Argosy"
 			"hull damage" 400
 			"hit force" 1200
 	outfits
-		"Heavy Laser" 4
-		"Heavy Laser Turret" 2
+		"Heavy Laser" 2
+		"Meteor Missile Launcher" 2
+		"Meteor Missile" 70
+		"Heavy Laser Turret"
+		"Heavy Anti-Missile Turret"
 		
 		"NT-200 Nucleovoltaic"
 		"LP072a Battery Pack"
@@ -2076,10 +2112,10 @@ ship "Modified Argosy"
 	engine 20 91
 	gun -22 -37 "Heavy Laser"
 	gun 22 -37 "Heavy Laser"
-	gun -23 -37 "Heavy Laser"
-	gun 23 -37 "Heavy Laser"
+	gun -23 -37 "Meteor Missile Launcher"
+	gun 23 -37 "Meteor Missile Launcher"
 	turret 0 -12 "Heavy Laser Turret"
-	turret 0 8 "Heavy Laser Turret"
+	turret 0 8 "Heavy Anti-Missile Turret"
 	leak "leak" 70 50
 	leak "flame" 30 80
 	explode "tiny explosion" 10
@@ -2215,7 +2251,7 @@ ship "Osprey"
 	thumbnail "thumbnail/osprey"
 	attributes
 		category "Medium Warship"
-		"cost" 4400000
+		"cost" 3400000
 		"shields" 7200
 		"hull" 1600
 		"required crew" 9
@@ -2235,12 +2271,13 @@ ship "Osprey"
 			"hit force" 1200
 	outfits
 		"Plasma Cannon" 4
-		"Quad Blaster Turret" 2
+		"Quad Blaster Turret"
+		"Heavy Anti-Missile Turret"
 		
 		"Breeder Reactor"
-		"LP072a Battery Pack"
+		"LP036a Battery Pack"
 		"D41-HY Shield Generator"
-		"Small Radar Jammer" 2
+		"Large Radar Jammer"
 		"Liquid Helium Cooler"
 		
 		"Impala Plasma Thruster"
@@ -2254,7 +2291,7 @@ ship "Osprey"
 	gun -26 -53 "Plasma Cannon"
 	gun 26 -53 "Plasma Cannon"
 	turret -16 -16 "Quad Blaster Turret"
-	turret 16 -16 "Quad Blaster Turret"
+	turret 16 -16 "Heavy Anti-Missile Turret"
 	leak "leak" 40 50
 	leak "flame" 80 80
 	leak "big leak" 80 30
@@ -2291,9 +2328,10 @@ ship "Protector"
 			"hull damage" 800
 			"hit force" 2400
 	outfits
-		"Torpedo Launcher" 2
-		"Torpedo" 60
-		"Quad Blaster Turret" 6
+		"Sidewinder Missile Launcher" 2
+		"Sidewinder Missile" 100
+		"Quad Blaster Turret" 4
+		"Heavy Anti-Missile Turret" 2
 		
 		"Fusion Reactor"
 		"LP288a Battery Pack"
@@ -2307,12 +2345,12 @@ ship "Protector"
 		
 	engine -11 125
 	engine 11 125
-	gun -15 -100 "Torpedo Launcher"
-	gun 15 -100 "Torpedo Launcher"
+	gun -15 -100 "Sidewinder Missile Launcher"
+	gun 15 -100 "Sidewinder Missile Launcher"
 	turret -54 -54 "Quad Blaster Turret"
 	turret 54 -54 "Quad Blaster Turret"
-	turret -73 0 "Quad Blaster Turret"
-	turret 73 0 "Quad Blaster Turret"
+	turret -73 0 "Heavy Anti-Missile Turret"
+	turret 73 0 "Heavy Anti-Missile Turret"
 	turret -54 54 "Quad Blaster Turret"
 	turret 54 54 "Quad Blaster Turret"
 	leak "leak" 60 50
@@ -2406,6 +2444,7 @@ ship "Rainmaker"
 		"nGVF-CC Fuel Cell"
 		"LP036a Battery Pack"
 		"D14-RN Shield Generator"
+		"Large Radar Jammer"
 		
 		"X2700 Ion Thruster"
 		"X2200 Ion Steering"
@@ -2452,7 +2491,9 @@ ship "Raven"
 			"hull damage" 300
 			"hit force" 900
 	outfits
-		"Heavy Laser" 4
+		"Heavy Laser" 2
+		"Sidewinder Missile Launcher" 2
+		"Sidewinder Missile" 100
 		
 		"RT-I Radiothermal"
 		"LP072a Battery Pack"
@@ -2466,8 +2507,8 @@ ship "Raven"
 	engine 12 43
 	gun -10 -33 "Heavy Laser"
 	gun 10 -33 "Heavy Laser"
-	gun -16 -28 "Heavy Laser"
-	gun 16 -28 "Heavy Laser"
+	gun -16 -28 "Sidewinder Missile Launcher"
+	gun 16 -28 "Sidewinder Missile Launcher"
 	leak "leak" 60 50
 	leak "flame" 50 80
 	explode "medium explosion" 24
@@ -2729,7 +2770,9 @@ ship "Sparrow"
 			"hull damage" 80
 			"hit force" 240
 	outfits
-		"Beam Laser" 2
+		"Beam Laser"
+		"Meteor Missile Launcher"
+		"Meteor Missile" 35
 		
 		"nGVF-BB Fuel Cell"
 		"LP036a Battery Pack"
@@ -2741,8 +2784,8 @@ ship "Sparrow"
 		
 	engine -5 35
 	engine 5 35
-	gun -7 -10
-	gun 7 -10
+	gun -7 -10 "Beam Laser"
+	gun 7 -10 "Meteor Missile Launcher"
 	leak "flame" 60 80
 	explode "tiny explosion" 15
 	explode "small explosion" 5
@@ -2776,7 +2819,8 @@ ship "Splinter"
 			"hit force" 900
 	outfits
 		"Proton Gun" 2
-		"Blaster Turret" 3
+		"Blaster Turret" 2
+		"Anti-Missile Turret"
 		
 		"RT-I Radiothermal"
 		"LP144a Battery Pack"
@@ -2793,7 +2837,7 @@ ship "Splinter"
 	gun -15 -80 "Proton Gun"
 	gun 15 -80 "Proton Gun"
 	turret -17 -28 "Blaster Turret"
-	turret 0 -28 "Blaster Turret"
+	turret 0 -28 "Anti-Missile Turret"
 	turret 17 -28 "Blaster Turret"
 	leak "leak" 60 50
 	leak "flame" 40 80
@@ -3022,12 +3066,13 @@ ship "Wasp"
 			"hit force" 300
 	outfits
 		"Energy Blaster" 2
-		"Javelin Pod"
-		"Javelin" 200
+		"Sidewinder Missile Launcher"
+		"Sidewinder Missile" 50
 		
 		"nGVF-BB Fuel Cell"
 		"LP036a Battery Pack"
 		"D14-RN Shield Generator"
+		"Small Radar Jammer"
 		
 		"X2700 Ion Thruster"
 		"X2200 Ion Steering"
@@ -3035,7 +3080,7 @@ ship "Wasp"
 		
 	engine -6 33
 	engine 6 33
-	gun 0 -38 "Javelin Pod"
+	gun 0 -38 "Sidewinder Missile Launcher"
 	gun -13 -31 "Energy Blaster"
 	gun 13 -31 "Energy Blaster"
 	leak "leak" 60 50

--- a/data/syndicate world jobs.txt
+++ b/data/syndicate world jobs.txt
@@ -24,7 +24,7 @@ mission "Transport executive to <planet>"
 		government Republic "Free Worlds" Syndicate Neutral Quarg
 		attributes paradise rich core "near earth"
 	on complete
-		payment 1000 170
+		payment 5000 170
 		dialog "The executive rushes off your ship without even a goodbye, fancy briefcase in hand. You collect your payment of <payment>."
 
 

--- a/data/syndicate world jobs.txt
+++ b/data/syndicate world jobs.txt
@@ -24,7 +24,7 @@ mission "Transport executive to <planet>"
 		government Republic "Free Worlds" Syndicate Neutral Quarg
 		attributes paradise rich core "near earth"
 	on complete
-		payment 5000 170
+		payment 1000 170
 		dialog "The executive rushes off your ship without even a goodbye, fancy briefcase in hand. You collect your payment of <payment>."
 
 

--- a/data/variants.txt
+++ b/data/variants.txt
@@ -820,6 +820,18 @@ ship "Firebird" "Firebird (Plasma)"
 		"Hyperdrive"
 
 
+ship "Firebird" "Firebird (Laser)"
+	outfits
+		"Heavy Laser" 4
+		"Heavy Laser Turret" 2
+		"RT-I Radiothermal"
+		"nGVF-AA Fuel Cell"
+		"LP144a Battery Pack"
+		"D41-HY Shield Generator"
+		"X3700 Ion Thruster"
+		"X3200 Ion Steering"
+		"Hyperdrive"
+
 
 ship "Flivver" "Flivver (Hai)"
 	outfits

--- a/data/variants.txt
+++ b/data/variants.txt
@@ -177,7 +177,8 @@ ship "Barb" "Barb (Gatling)"
 ship "Bastion" "Bastion (Heavy)"
 	outfits
 		"Plasma Cannon" 4
-		"Quad Blaster Turret" 3
+		"Quad Blaster Turret" 2
+		"Anti-Missile Turret"
 		"Fusion Reactor"
 		"LP072a Battery Pack"
 		"D67-TM Shield Generator"
@@ -186,6 +187,9 @@ ship "Bastion" "Bastion (Heavy)"
 		"X3700 Ion Thruster"
 		"Orca Plasma Steering"
 		"Hyperdrive"
+	turret "Anti-Missile Turret"
+	turret "Quad Blaster Turret"
+	turret "Quad Blaster Turret"
 
 
 ship "Bastion" "Bastion (Laser)"
@@ -325,6 +329,22 @@ ship "Berserker" "Berserker (Afterburner)"
 
 
 
+ship "Berserker" "Berserker (Strike Fighter)"
+	outfits
+		"Heavy Rocket Launcher"
+		"Heavy Rocket" 20
+		"Sidewinder Missile Launcher"
+		"Sidewinder Missile" 50
+		"nGVF-CC Fuel Cell"
+		"Supercapacitor"
+		"D23-QP Shield Generator"
+		"Ramscoop"
+		"Chipmunk Plasma Thruster"
+		"Chipmunk Plasma Steering"
+		"Hyperdrive"
+
+
+
 ship "Bounder" "Bounder (Hai)"
 	outfits
 		"Pulse Turret"
@@ -416,12 +436,13 @@ ship "Carrier" "Carrier (Jump)"
 		"Particle Cannon" 4
 		"Sidewinder Missile Launcher" 4
 		"Sidewinder Missile" 200
-		"Electron Turret" 3
-		"Heavy Anti-Missile Turret"
+		"Electron Turret" 2
+		"Heavy Anti-Missile Turret" 2
 		"Armageddon Core"
 		"Dwarf Core"
 		"LP072a Battery Pack"
 		"D94-YV Shield Generator"
+		"Large Radar Jammer"
 		"Liquid Helium Cooler"
 		"Water Coolant System"
 		"Fuel Pod"
@@ -438,7 +459,7 @@ ship "Carrier" "Carrier (Jump)"
 	gun "Sidewinder Missile Launcher"
 	gun "Sidewinder Missile Launcher"
 	turret "Electron Turret"
-	turret "Electron Turret"
+	turret "Heavy Anti-Missile Turret"
 	turret "Heavy Anti-Missile Turret"
 	turret "Electron Turret"
 
@@ -448,12 +469,13 @@ ship "Carrier" "Carrier (Mark II)"
 		"Particle Cannon" 4
 		"Sidewinder Missile Launcher" 4
 		"Sidewinder Missile" 200
-		"Electron Turret" 3
-		"Heavy Anti-Missile Turret"
+		"Electron Turret" 2
+		"Heavy Anti-Missile Turret" 2
 		"Armageddon Core"
 		"Dwarf Core"
 		"LP072a Battery Pack"
 		"D94-YV Shield Generator"
+		"Large Radar Jammer" 2
 		"Liquid Helium Cooler"
 		"Outfits Expansion" 3
 		"A860 Atomic Thruster"
@@ -468,7 +490,7 @@ ship "Carrier" "Carrier (Mark II)"
 	gun "Sidewinder Missile Launcher"
 	gun "Sidewinder Missile Launcher"
 	turret "Electron Turret"
-	turret "Electron Turret"
+	turret "Heavy Anti-Missile Turret"
 	turret "Heavy Anti-Missile Turret"
 	turret "Electron Turret"
 
@@ -579,6 +601,7 @@ ship "Cruiser" "Cruiser (Heavy)"
 		"Dwarf Core"
 		"Supercapacitor"
 		"D94-YV Shield Generator"
+		"Small Radar Jammer" 2
 		"Liquid Helium Cooler"
 		"Ramscoop"
 		"Outfits Expansion"
@@ -610,6 +633,7 @@ ship "Cruiser" "Cruiser (Jump)"
 		"LP144a Battery Pack"
 		"LP036a Battery Pack"
 		"D94-YV Shield Generator"
+		"Small Radar Jammer"
 		"Liquid Helium Cooler"
 		"Fuel Pod" 2
 		"Ramscoop"
@@ -635,11 +659,13 @@ ship "Cruiser" "Cruiser (Mark II)"
 		"Typhoon Torpedo" 60
 		"Sidewinder Missile Launcher" 4
 		"Sidewinder Missile" 200
-		"Electron Turret" 3
-		"Heavy Anti-Missile Turret"
+		"Electron Turret" 2
+		"Heavy Anti-Missile Turret" 2
 		"Armageddon Core"
 		"LP144a Battery Pack"
 		"D94-YV Shield Generator"
+		"Large Radar Jammer"
+		"Small Radar Jammer" 2
 		"Liquid Helium Cooler"
 		"Fuel Pod"
 		"A520 Atomic Thruster"
@@ -651,7 +677,7 @@ ship "Cruiser" "Cruiser (Mark II)"
 	gun "Sidewinder Missile Launcher"
 	gun "Typhoon Launcher"
 	gun "Typhoon Launcher"
-	turret "Electron Turret"
+	turret "Heavy Anti-Missile Turret"
 	turret "Electron Turret"
 	turret "Electron Turret"
 	turret "Heavy Anti-Missile Turret"
@@ -660,9 +686,10 @@ ship "Cruiser" "Cruiser (Mark II)"
 
 ship "Dreadnought" "Dreadnought (Jump)"
 	outfits
-		"Meteor Missile Launcher" 4
-		"Meteor Missile" 140
-		"Plasma Turret" 5
+		"Torpedo Launcher" 4
+		"Torpedo" 120
+		"Plasma Turret" 3
+		"Heavy Anti-Missile Turret" 2
 		"Stack Core"
 		"LP144a Battery Pack"
 		"D41-HY Shield Generator"
@@ -671,6 +698,11 @@ ship "Dreadnought" "Dreadnought (Jump)"
 		"Orca Plasma Thruster"
 		"Orca Plasma Steering"
 		"Jump Drive"
+	turret "Plasma Turret"
+	turret "Heavy Anti-Missile Turret"
+	turret "Heavy Anti-Missile Turret"
+	turret "Plasma Turret"
+	turret "Plasma Turret"
 
 
 
@@ -680,7 +712,8 @@ ship "Falcon" "Falcon (Heavy)"
 		"Torpedo" 60
 		"Meteor Missile Launcher" 2
 		"Meteor Missile" 70
-		"Heavy Laser Turret" 4
+		"Heavy Laser Turret" 3
+		"Heavy Anti-Missile Turret"
 		"Fusion Reactor"
 		"D67-TM Shield Generator"
 		"Small Radar Jammer"
@@ -696,7 +729,8 @@ ship "Falcon" "Falcon (Heavy)"
 ship "Falcon" "Falcon (Laser)"
 	outfits
 		"Heavy Laser" 4
-		"Heavy Laser Turret" 4
+		"Heavy Laser Turret" 3
+		"Heavy Anti-Missile Turret"
 		"Breeder Reactor"
 		"LP072a Battery Pack"
 		"D94-YV Shield Generator"
@@ -886,6 +920,7 @@ ship "Frigate" "Frigate (Mark II)"
 		"Dwarf Core"
 		"LP036a Battery Pack"
 		"D41-HY Shield Generator"
+		"Small Radar Jammer"
 		"Water Coolant System"
 		"Outfits Expansion"
 		"X3700 Ion Thruster"
@@ -935,12 +970,40 @@ ship "Fury" "Fury (Laser)"
 
 ship "Fury" "Fury (Missile)"
 	outfits
-		"Meteor Missile Launcher" 4
-		"Meteor Missile" 140
+		"Javelin Pod"
+		"Javelin" 200
+		"Meteor Missile Launcher" 2
+		"Meteor Missile" 70
 		"nGVF-BB Fuel Cell"
 		"Supercapacitor" 3
 		"D14-RN Shield Generator"
 		"Greyhound Plasma Thruster"
+		"Chipmunk Plasma Steering"
+		"Hyperdrive"
+
+ship "Fury" "Fury (Bomber)"
+	outfits
+		"Heavy Rocket Launcher"
+		"Heavy Rocket" 20
+		"Meteor Missile Launcher" 2
+		"Meteor Missile" 70
+		"nGVF-BB Fuel Cell"
+		"Supercapacitor"
+		"D14-RN Shield Generator"
+		"Small Radar Jammer" 2
+		"X2700 Ion Thruster"
+		"Chipmunk Plasma Steering"
+		"Hyperdrive"
+
+ship "Fury" "Fury (Heavy)"
+	outfits
+		"Proton Gun"
+		"Javelin Pod"
+		"Javelin" 200
+		"nGVF-BB Fuel Cell"
+		"LP036a Battery Pack"
+		"D14-RN Shield Generator"
+		"X2700 Ion Thruster"
 		"Chipmunk Plasma Steering"
 		"Hyperdrive"
 
@@ -1046,6 +1109,30 @@ ship "Hawk" "Hawk (Speedy)"
 		"A255 Atomic Steering"
 		"Hyperdrive"
 
+ship "Hawk" "Hawk (Bomber)"
+	outfits
+		"Heavy Rocket Launcher"
+		"Heavy Rocket" 20
+		"Torpedo Launcher"
+		"Torpedo" 30
+		"nGVF-CC Fuel Cell"
+		"Supercapacitor"
+		"D41-HY Shield Generator"
+		"Small Radar Jammer" 2
+		"X2700 Ion Thruster"
+		"Greyhound Plasma Steering"
+		"Hyperdrive"
+
+
+ship "Hawk" "Hawk (Plasma)"
+	outfits
+		"Plasma Cannon" 2
+		"RT-I Radiothermal"
+		"LP036a Battery Pack"
+		"D23-QP Shield Generator"
+		"X2700 Ion Thruster"
+		"Greyhound Plasma Steering"
+		"Hyperdrive"
 
 
 ship "Headhunter" "Headhunter (Hai)"
@@ -1068,6 +1155,22 @@ ship "Headhunter" "Headhunter (Particle)"
 		"D23-QP Shield Generator"
 		"A250 Atomic Thruster"
 		"A375 Atomic Steering"
+		"Hyperdrive"
+
+
+ship "Headhunter" "Headhunter (Heavy Strike Fighter)"
+	outfits
+		"Heavy Laser" 2
+		"Torpedo Launcher"
+		"Torpedo" 30
+		"Sidewinder Missile Launcher"
+		"Sidewinder Missile" 50
+		"Anti-Missile Turret"
+		"RT-I Radiothermal"
+		"LP072a Battery Pack"
+		"D23-QP Shield Generator"
+		"Greyhound Plasma Thruster"
+		"Greyhound Plasma Steering"
 		"Hyperdrive"
 
 
@@ -1132,7 +1235,8 @@ ship "Leviathan" "Leviathan (Heavy)"
 		"Torpedo" 60
 		"Meteor Missile Launcher" 2
 		"Meteor Missile" 70
-		"Heavy Laser Turret" 4
+		"Heavy Laser Turret" 3
+		"Heavy Anti-Missile Turret"
 		"Breeder Reactor"
 		"LP036a Battery Pack"
 		"D94-YV Shield Generator" 2
@@ -1146,12 +1250,17 @@ ship "Leviathan" "Leviathan (Heavy)"
 	gun "Meteor Missile Launcher"
 	gun "Torpedo Launcher"
 	gun "Torpedo Launcher"
+	turret "Heavy Laser Turret"
+	turret "Heavy Laser Turret"
+	turret "Heavy Anti-Missile Turret"
+	turret "Heavy Laser Turret"
 
 
 ship "Leviathan" "Leviathan (Laser)"
 	outfits
 		"Heavy Laser" 4
-		"Heavy Laser Turret" 4
+		"Heavy Laser Turret" 3
+		"Heavy Anti-Missile Turret"
 		"Armageddon Core"
 		"LP036a Battery Pack"
 		"Supercapacitor"
@@ -1161,6 +1270,10 @@ ship "Leviathan" "Leviathan (Laser)"
 		"A370 Atomic Thruster"
 		"A525 Atomic Steering"
 		"Hyperdrive"
+	turret "Heavy Laser Turret"
+	turret "Heavy Laser Turret"
+	turret "Heavy Anti-Missile Turret"
+	turret "Heavy Laser Turret"
 
 
 
@@ -1229,7 +1342,8 @@ ship "Manta" "Manta (Proton)"
 ship "Modified Argosy" "Modified Argosy (Blaster)"
 	outfits
 		"Modified Blaster" 4
-		"Quad Blaster Turret" 2
+		"Quad Blaster Turret"
+		"Heavy Anti-Missile Turret"
 		"Fission Reactor"
 		"LP144a Battery Pack"
 		"D67-TM Shield Generator"
@@ -1243,7 +1357,8 @@ ship "Modified Argosy" "Modified Argosy (Blaster)"
 ship "Modified Argosy" "Modified Argosy (Heavy)"
 	outfits
 		"Heavy Laser" 4
-		"Heavy Laser Turret" 2
+		"Heavy Laser Turret"
+		"Heavy Anti-Missile Turret"
 		"Fission Reactor"
 		"LP036a Battery Pack"
 		"D23-QP Shield Generator"
@@ -1358,7 +1473,8 @@ ship "Osprey" "Osprey (Alien Weapons)"
 ship "Osprey" "Osprey (Laser)"
 	outfits
 		"Heavy Laser" 4
-		"Heavy Laser Turret" 2
+		"Heavy Laser Turret"
+		"Heavy Anti-Missile Turret"
 		"Breeder Reactor"
 		"LP036a Battery Pack"
 		"Supercapacitor" 4
@@ -1375,7 +1491,8 @@ ship "Osprey" "Osprey (Missile)"
 		"Torpedo" 60
 		"Heavy Rocket Launcher" 2
 		"Heavy Rocket" 40
-		"Heavy Laser Turret" 2
+		"Heavy Laser Turret"
+		"Heavy Anti-Missile Turret"
 		"Breeder Reactor"
 		"LP036a Battery Pack"
 		"Supercapacitor" 3
@@ -1393,7 +1510,9 @@ ship "Osprey" "Osprey (Missile)"
 
 ship "Protector" "Protector (Laser)"
 	outfits
-		"Laser Turret" 2
+		"Sidewinder Missile Launcher" 2
+		"Sidewinder Missile" 100
+		"Anti-Missile Turret" 2
 		"Heavy Laser Turret" 4
 		"Fusion Reactor"
 		"LP036a Battery Pack"
@@ -1403,17 +1522,20 @@ ship "Protector" "Protector (Laser)"
 		"A370 Atomic Thruster"
 		"A375 Atomic Steering"
 		"Hyperdrive"
-	turret "Laser Turret"
-	turret "Laser Turret"
 	turret "Heavy Laser Turret"
 	turret "Heavy Laser Turret"
+	turret "Anti-Missile Turret"
+	turret "Anti-Missile Turret"
 	turret "Heavy Laser Turret"
 	turret "Heavy Laser Turret"
 
 
 ship "Protector" "Protector (Proton)"
 	outfits
-		"Proton Turret" 6
+		"Meteor Missile Launcher" 2
+		"Meteor Missile" 70
+		"Proton Turret" 4
+		"Heavy Anti-Missile Turret" 2
 		"Fusion Reactor"
 		"LP036a Battery Pack"
 		"Supercapacitor" 3
@@ -1422,6 +1544,12 @@ ship "Protector" "Protector (Proton)"
 		"A370 Atomic Thruster"
 		"A375 Atomic Steering"
 		"Hyperdrive"
+	turret "Proton Turret"
+	turret "Proton Turret"
+	turret "Heavy Anti-Missile Turret"
+	turret "Heavy Anti-Missile Turret"
+	turret "Proton Turret"
+	turret "Proton Turret"
 
 
 
@@ -1688,6 +1816,32 @@ ship "Vanguard" "Vanguard (Particle)"
 
 
 
+ship "Vanguard" "Vanguard (Missile)"
+	outfits
+		"Sidewinder Missile Launcher" 4
+		"Sidewinder Missile" 200
+		"Torpedo Launcher" 3
+		"Torpedo" 90
+		"Heavy Anti-Missile Turret"
+		"Fission Reactor"
+		"Supercapacitor"
+		"D94-YV Shield Generator" 2
+		"Large Radar Jammer" 2
+		"Liquid Nitrogen Cooler"
+		"X3700 Ion Thruster"
+		"X4200 Ion Steering"
+		"Hyperdrive"
+	gun "Torpedo Launcher"
+	gun "Torpedo Launcher"
+	gun "Torpedo Launcher"
+	gun "Sidewinder Missile Launcher"
+	gun "Sidewinder Missile Launcher"
+	gun "Sidewinder Missile Launcher"
+	gun "Sidewinder Missile Launcher"
+	turret "Heavy Anti-Missile Turret"
+
+
+
 ship "Wasp" "Wasp (Proton)"
 	outfits
 		"Proton Gun"
@@ -1697,3 +1851,23 @@ ship "Wasp" "Wasp (Proton)"
 		"X2700 Ion Thruster"
 		"X2200 Ion Steering"
 		"Hyperdrive"
+	gun "Proton Gun"
+	gun
+	gun
+
+
+
+ship "Wasp" "Wasp (Bomber)"
+	outfits
+		"Beam Laser"
+		"Meteor Missile Launcher" 2
+		"Meteor Missile" 70
+		"nGVF-BB Fuel Cell"
+		"LP036a Battery Pack"
+		"D14-RN Shield Generator"
+		"X2700 Ion Thruster"
+		"X2200 Ion Steering"
+		"Hyperdrive"
+	gun "Meteor Missile Launcher"
+	gun "Beam Laser"
+	gun "Meteor Missile Launcher"

--- a/data/variants.txt
+++ b/data/variants.txt
@@ -329,7 +329,7 @@ ship "Berserker" "Berserker (Afterburner)"
 
 
 
-ship "Berserker" "Berserker (Strike Fighter)"
+ship "Berserker" "Berserker (Strike)"
 	outfits
 		"Heavy Rocket Launcher"
 		"Heavy Rocket" 20
@@ -1158,9 +1158,8 @@ ship "Headhunter" "Headhunter (Particle)"
 		"Hyperdrive"
 
 
-ship "Headhunter" "Headhunter (Heavy Strike Fighter)"
+ship "Headhunter" "Headhunter (Strike)"
 	outfits
-		"Heavy Laser" 2
 		"Torpedo Launcher"
 		"Torpedo" 30
 		"Sidewinder Missile Launcher"

--- a/data/weapons.txt
+++ b/data/weapons.txt
@@ -782,7 +782,7 @@ outfit "Javelin Pod"
 		"hit force" 50
 		"missile strength" 2
 	description "The Javelin Pod fires a rapid stream of unguided missiles. A Javelin Pod does far more damage than any gun of a comparable size, and has a longer range as well, but once a ship has expended all of its ammunition it must leave combat and find a planet where it can buy more, which makes Javelins less useful in protracted battles."
-	description "	The weapon's high rate of fire also makes it useful for saturating well-protected ships' anti-missile defenses so that more dangerous projectiles can sneak through."
+	description "	The weapon's high rate of fire also makes it useful for saturating well-protected ships' anti-missile defenses so that more dangerous projectiles fired by allied ships can sneak through."
 
 
 outfit "Torpedo"

--- a/data/weapons.txt
+++ b/data/weapons.txt
@@ -781,7 +781,8 @@ outfit "Javelin Pod"
 		"hull damage" 36
 		"hit force" 50
 		"missile strength" 2
-	description "The Javelin Pod fires a rapid stream of unguided missiles. A Javelin Pod does far more damage than any gun of a comparable size, and has a longer range as well, but once a ship has fired off all its ammunition it must leave combat and find a planet where it can buy more, which makes Javelins less useful in protracted battles. As a result, they are very popular with pirates as a way to quickly disable a small target."
+	description "The Javelin Pod fires a rapid stream of unguided missiles. A Javelin Pod does far more damage than any gun of a comparable size, and has a longer range as well, but once a ship has expended all of its ammunition it must leave combat and find a planet where it can buy more, which makes Javelins less useful in protracted battles."
+	description "	The weapon's high rate of fire also makes it useful for saturating well-protected ships' anti-missile defenses so that more dangerous projectiles can sneak through."
 
 
 outfit "Torpedo"


### PR DESCRIPTION
Ref: endless-sky/endless-sky#3922

> 
> # Changes
> 
> This PR changes the default loadout of many ships and variants to reflect the logical conclusions of the recent missile tweak and improve in-game realism, fun, and tactical opportunities.
> 
> In a nutshell, here are the changes:
> 
>   * Most ships that previously had no missile armament now have some according to their typical default battle roles:
>       
>     * Interceptor/fighter: meteor, sidewinder, or javelin launchers
>     * Interceptor-killer/anti-fighter defense: sidewinder missile launchers
>     * Capital ship bombardment: torpedo launchers
>     * Multirole/pirate/anti-merchant: meteor missile launchers
> 
>   * Nearly all fighters, interceptors, and light warships have a Small Radar Jammer. [In the event that these outfits ever become useful](https://github.com/endless-sky/endless-sky/issues/3912), they should allow these ships to have a modicum of a chance against sidewinder missiles. It seemed logical that countermeasures against anti-fighter missiles would be more or less standard equipment.
> 
>   * All turreted ships that previously lacked an anti-missile turret got one. Even before my missile changes, it was always odd how some large slow ships like Modified Argosies let you pound them to death with Meteors at long range with no defense whatsoever. No more. Large capital ships generally mount two Heavy Anti-Missile Turrets--one of the ways you can distinguish them from smaller lighter warships.
> 
>   * Added a number of new variants that are heavily armed with missiles. Check out the `Vanguard (Missile)` variant, which is basically an [arsenal ship](https://en.wikipedia.org/wiki/Arsenal_ship).
> 
>   * More fleets include heavy missile-armed interceptor and light warship escorts.
> 
>   * Gave the Hawk 10 more weapon space and reduced its Cargo space by 10. This was the only way I was able to make the Hawk actually excel at anything over a Berserker or a Fury. With 50 tons, they can carry a mix-and-match assortment of Plasma cannons and Torpedo Launchers, making them truly useful bomber craft.
> 
> 
> # Testing
> 
>   * Played through the entire Free Worlds campaign in various ships, some armed with missile weapons, and some armed exclusively with guns and turrets.
>       
>     * Early game was no more difficult than it was before with all three ships
>     * No major change to the overall balance during the campaign
>     * In some cases, short-range battles are a bit slower because of the replacement of guns and gun turrets with missile weaponry. I think this is a good thing overall, since fleet battles in Endless Sky are generally over very quickly.
> 
>   * Made sure all changed ships and variants could fit their new loadouts, and that their energy and heat profiles still made sense. Made minor tweaks to preserve these where appropriate.
> 
> 
> # Feelings
> 
> These changes make the game feel more tactically interesting to me. Now that missiles are a genuine option and most ships are generally armed and defended accordingly, player armament choices are no longer a no-brainer: will you forget about missiles and close to knife fighting distance, taking advantage of your ship's superior short-range gun armament? Will you mount missiles to all of your gun ports and bombard your enemies from a distance, oversaturating their anti-missile defenses? Will you play it safe and be balanced, with some guns and some missiles? Fighters are actually more fun to play with now, since they're basically flying missile platforms, which can be very effective.
> 
> Overall I believe this PR improves the game's fun factor and realism, and opens new tactical possibilities.